### PR TITLE
Adds fields 17-24 to property assessments table

### DIFF
--- a/backend/db/migrate/20220817011608_create_property_assessments.rb
+++ b/backend/db/migrate/20220817011608_create_property_assessments.rb
@@ -1,6 +1,14 @@
 class CreatePropertyAssessments < ActiveRecord::Migration[7.0]
   def change
     create_table :property_assessments do |t|
+      t.string :mail_addressee
+      t.string :mail_address
+      t.string :mail_city
+      t.string :mail_state, :limit => 2
+      t.string :mail_zipcode # these can be 5 or zip+4 format
+      t.float :res_floor
+      t.integer :cd_floor
+      t.integer :res_units
 
       t.timestamps
     end


### PR DESCRIPTION
This adds my assigned fields to the table. I ran it locally to test, now I will roll it back until all the fields are ready (tried rake `db:migrate --dry-run` and that didn't produce any useful output)
Examined table in postgres and it looks good.

For reference:

MAIL_ADDRESSEE Care of recipient
MAIL_ADDRESS Street address where tax bill is mailed
MAIL_CITY City/neighborhood where tax bill is mailed
MAIL_STATE State where tax bill is mailed
MAIL_ZIPCODE Zip code where tax bill is mailed
RES_FLOOR Number of floors
CD_FLOORN umber of floors of condominium unit 
RES_UNITS Number of Residential units
