### PR TITLE
Add fields 25-32 to property assessments table

### DIFF
--- a/backend/db/migrate/20220817011608_create_property_assessments.rb
+++ b/backend/db/migrate/20220817011608_create_property_assessments.rb
@@ -1,6 +1,14 @@
 class CreatePropertyAssessments < ActiveRecord::Migration[7.0]
   def change
     create_table :property_assessments do |t|
+      t.integer :com_units
+      t.integer :rc_units
+      t.float :land_sf
+      t.float :gross_area
+      t.float :living_area
+      t.decimal :land_value
+      t.decimal :bldg_value
+      t.decimal :total_value
 
       t.timestamps
     end

--- a/backend/db/migrate/20220817011608_create_property_assessments.rb
+++ b/backend/db/migrate/20220817011608_create_property_assessments.rb
@@ -3,12 +3,12 @@ class CreatePropertyAssessments < ActiveRecord::Migration[7.0]
     create_table :property_assessments do |t|
       t.integer :com_units
       t.integer :rc_units
-      t.float :land_sf
-      t.float :gross_area
-      t.float :living_area
-      t.decimal :land_value
-      t.decimal :bldg_value
-      t.decimal :total_value
+      t.integer :land_sf
+      t.integer :gross_area
+      t.integer :living_area
+      t.integer :land_value
+      t.integer :bldg_value
+      t.integer :total_value
 
       t.timestamps
     end


### PR DESCRIPTION
Any feedback on datatype choice here would be appreciated. I was mainly using[ this stack overflow post](https://stackoverflow.com/questions/1056323/difference-between-numeric-float-and-decimal-in-sql-server) as a reference for decimal vs float types comparison. 

COM_UNITS     - Number of Commercial Units
RC_UNITS         - Number of Residential/Commercial Units in a condominium building
LAND_SF          - Parcel’s land area in square feet (legal area)
GROSS_AREA   - Gross floor area 
LIVING_AREA   - Living area square footage of the property
LAND_VALUE   - Total assessed land value
BLDG_VALUE    - Total assessed building value
TOTAL_VALUE   - Total assessed value for property