### PR TITLE
Account Edit page

### DIFF
--- a/frontend/front/src/features/account/accountSlice.js
+++ b/frontend/front/src/features/account/accountSlice.js
@@ -1,0 +1,34 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+  firstName: "John",
+  lastName: "Smith",
+  email: "jsmith@example.com",
+  address: "12345 John Smith Way",
+  phoneNumber: "1234567890",
+};
+
+const accountSlice = createSlice({
+  name: "account",
+  initialState,
+  reducers: {
+    setAccount: (state, action) => {
+      state.firstName = action.payload.firstName;
+      state.lastName = action.payload.lastName;
+      state.email = action.payload.email;
+      state.address = action.payload.address;
+      state.phoneNumber = action.payload.phoneNumber;
+    },
+    setLogOut: (state) => {
+      state.firstName = null;
+      state.lastName = null;
+      state.email = null;
+      state.address = null;
+      state.phoneNumber = null;
+    },
+  },
+});
+
+export const { setAccount, setLogOut } = accountSlice.actions;
+
+export default accountSlice.reducer;

--- a/frontend/front/src/pages/Surveyor/SurveyorContainer.js
+++ b/frontend/front/src/pages/Surveyor/SurveyorContainer.js
@@ -7,6 +7,7 @@ import Login from "./login/Login";
 import Dashboard from "./dashboard/Dashboard";
 import Account from "./account/Account";
 import HouseProfile from "./houseProfile/HouseProfile";
+import EditAccount from "./account/edit/EditAccount";
 
 const SurveyorContainer = () => {
   const { authenticated } = useSelector((state) => state.login);
@@ -19,6 +20,7 @@ const SurveyorContainer = () => {
           <Route path='/' element={<Login />}></Route>
           <Route path='dashboard' element={<Dashboard />}></Route>
           <Route path='account' element={<Account />}></Route>
+          <Route path='account/edit' element={<EditAccount />}></Route>
           <Route path='house' element={<HouseProfile />}></Route>
         </Routes>
       </Box>

--- a/frontend/front/src/pages/Surveyor/account/Account.js
+++ b/frontend/front/src/pages/Surveyor/account/Account.js
@@ -1,32 +1,39 @@
 import { Box, Button, Grid, Typography } from "@mui/material";
 import React from "react";
 import AccountDetail from "./AccountDetail";
+import { Link } from "react-router-dom";
+import { useSelector } from "react-redux";
 
 const Account = () => {
+  const { firstName, lastName, email, address, phoneNumber } = useSelector(
+    (state) => state.account
+  );
   return (
     <Box>
-      <Grid container direction='column' rowSpacing={1}>
+      <Grid container direction="column" rowSpacing={1}>
         <Grid item xs={12}>
-          <Box display='flex' px={2} pt={3}>
-            <Typography variant='h2' component='h2'>
+          <Box display="flex" px={2} pt={3}>
+            <Typography variant="h2" component="h2">
               My Account
             </Typography>
           </Box>
         </Grid>
-        <AccountDetail label='First Name' value='John' />
-        <AccountDetail label='Last Name' value='Smith' />
-        <AccountDetail label='Email' value='jsmith@example.com' />
-        <AccountDetail label='Address' value='12345 John Smith Way' />
-        <AccountDetail label='Phone Number' value='(123) 456-7890' />
+        <AccountDetail label="First Name" value={firstName} />
+        <AccountDetail label="Last Name" value={lastName} />
+        <AccountDetail label="Email" value={email} />
+        <AccountDetail label="Address" value={address} />
+        <AccountDetail label="Phone Number" value={phoneNumber} />
       </Grid>
-      <Grid container direction='column' rowSpacing={4}>
+      <Grid container direction="column" rowSpacing={4}>
         <Grid item xs={12}>
-          <Box display='flex' mt={3} mb={2} px={2}>
-            <Button variant='contained'>Edit</Button>
+          <Box display="flex" mt={3} mb={2} px={2}>
+            <Button variant="contained" component={Link} to="edit">
+              Edit
+            </Button>
           </Box>
           <Box p={1} sx={{ borderBottom: "1px dashed grey" }} />
-          <Box display='flex' mt={3} mb={2} px={2}>
-            <Button variant='contained' disabled={true}>
+          <Box display="flex" mt={3} mb={2} px={2}>
+            <Button variant="contained" disabled={true}>
               Request New Assignment
             </Button>
           </Box>

--- a/frontend/front/src/pages/Surveyor/account/edit/EditAccount.js
+++ b/frontend/front/src/pages/Surveyor/account/edit/EditAccount.js
@@ -1,0 +1,207 @@
+import React from "react";
+import Button from "@mui/material/Button";
+import { Grid, Paper, TextField, Box } from "@mui/material";
+import { useForm } from "react-hook-form";
+import { useDispatch, useSelector } from "react-redux";
+import { setAccount } from "../../../../features/account/accountSlice";
+import { useNavigate, Link } from "react-router-dom";
+
+const EditAccount = () => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm();
+
+  const { firstName, lastName, email, address, phoneNumber } = useSelector(
+    (state) => state.account
+  );
+
+  const paperStyle = {
+    padding: 40,
+
+    display: "flex",
+    flexDirection: "column",
+    width: 280,
+    margin: "20px auto",
+  };
+
+  const btnstyle = { margin: "10px 0" };
+
+  const errorStyles = {
+    color: "rgb(239 68 68 / 1)",
+    fontSize: "0.875rem",
+    lineHeight: "1.25rem",
+  };
+
+  async function EditAccountForms(values) {
+    if (!values) return;
+
+    dispatch(
+      setAccount({
+        firstName: values.firstName,
+        lastName: values.lastName,
+        email: values.email,
+        address: values.address,
+        phoneNumber: values.phoneNumber,
+      })
+    );
+
+    reset();
+
+    navigate("../account");
+  }
+
+  return (
+    <Box>
+      <Paper elevation={5} style={paperStyle}>
+        <Grid align="center">
+          <h2>Update Account Details?</h2>
+        </Grid>
+
+        <form onSubmit={handleSubmit(EditAccountForms)}>
+          <TextField
+            id="standard-basic"
+            placeholder="Enter First Name"
+            type="text"
+            style={btnstyle}
+            name="firstName"
+            fullWidth
+            label="First Name"
+            variant="standard"
+            defaultValue={firstName}
+            {...register("firstName", {
+              required: {
+                value: true,
+                message: "Please Enter First Name",
+              },
+            })}
+          />
+          <span style={errorStyles}>{errors?.firstName?.message}</span>
+          <TextField
+            id="standard-basic"
+            placeholder="Enter Last Name"
+            type="text"
+            style={btnstyle}
+            name="lastName"
+            fullWidth
+            label="Last Name"
+            variant="standard"
+            defaultValue={lastName}
+            {...register("lastName", {
+              required: {
+                value: true,
+                message: "Please Enter Last Name",
+              },
+            })}
+          />
+          <span style={errorStyles}>{errors?.lastName?.message}</span>
+          <TextField
+            id="standard-basic"
+            placeholder="Enter Email"
+            type="email"
+            style={btnstyle}
+            name="email"
+            fullWidth
+            label="Email"
+            variant="standard"
+            defaultValue={email}
+            {...register("email", {
+              required: {
+                value: true,
+                message: "Please Enter Email",
+              },
+              pattern: {
+                value:
+                  /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+                message: "Please enter a valid email",
+              },
+            })}
+          />
+          <span style={errorStyles}>{errors?.email?.message}</span>
+          <TextField
+            id="standard-basic"
+            placeholder="Enter Address"
+            type="text"
+            style={btnstyle}
+            name="address"
+            fullWidth
+            label="Address"
+            variant="standard"
+            defaultValue={address}
+            {...register("address", {
+              required: {
+                value: true,
+                message: "Please Enter Address",
+              },
+            })}
+          />
+          <span style={errorStyles}>{errors?.address?.message}</span>
+          <TextField
+            id="standard-basic"
+            placeholder="Enter Phone Number"
+            type="tel"
+            style={btnstyle}
+            name="phoneNumber"
+            fullWidth
+            label="Phone Number"
+            variant="standard"
+            defaultValue={phoneNumber}
+            {...register("phoneNumber", {
+              required: {
+                value: true,
+                message: "Please Enter Phone Number",
+              },
+              maxLength: {
+                value: 11,
+                message: "Phone number too long",
+              },
+              minLength: {
+                value: 8,
+                message: "Phone number too short",
+              },
+            })}
+          />
+          <span style={errorStyles}>{errors?.phoneNumber?.message}</span>
+
+          <Button
+            type="submit"
+            color="primary"
+            variant="contained"
+            onClick={() => EditAccountForms}
+            style={{
+              btnstyle,
+              borderRadius: "20px",
+              marginTop: "20px",
+            }}
+            fullWidth
+          >
+            Save
+          </Button>
+          <Button
+            type="button"
+            color="error"
+            variant="contained"
+            onClick={() => EditAccountForms}
+            style={{
+              btnstyle,
+              borderRadius: "20px",
+              marginTop: "20px",
+            }}
+            fullWidth
+            component={Link}
+            to="../account"
+          >
+            Cancel
+          </Button>
+        </form>
+      </Paper>
+    </Box>
+  );
+};
+
+export default EditAccount;

--- a/frontend/front/src/redux/store.js
+++ b/frontend/front/src/redux/store.js
@@ -1,6 +1,7 @@
 import { configureStore } from "@reduxjs/toolkit";
 import homeReducer from "../features/home/homeSlice";
 import aboutReducer from "../features/about/aboutSlice";
+import accountReducer from "../features/account/accountSlice";
 import contactReducer from "../features/contact/contactSlice";
 import navReducer from "../features/nav/navSlice";
 import loginReducer from "../features/login/loginSlice";
@@ -9,6 +10,7 @@ export const store = configureStore({
   reducer: {
     home: homeReducer,
     about: aboutReducer,
+    account: accountReducer,
     contact: contactReducer,
     nav: navReducer,
     login: loginReducer,


### PR DESCRIPTION
Related to #78 

### Features:
- Adds `accountSlice` for managing account details
- Account details that are edited in the `EditAccount` form will be shown on the Account page (kept in local page state)
- Editing form has basic validation, requiring a value for all fields, email format validation, and enforcing phone numbers as being 8-11 characters - we should decide which of this validation makes sense

### Future TODO:
- Update route registration for `/account/edit` page to be more idiomatic
- Connect to API
- Use `setLogOut` action to clear local state when user logs out?
- Decide which fields should be mandatory and consider marking them with asterisks
- Update the look-and-feel to be less similar to the login page
- Update any fields that get changed when the surveyor user model is solidified (e.g. Address will likely become multiple parts)
- Auto-format phone numbers to divide the number visually into a `(XXX) XXX-XXXX` format

### Screenshots:
Desktop:
![image](https://user-images.githubusercontent.com/27782045/196542015-f4118c07-a725-4869-86b6-2de178d09782.png)

iPhone:
![image](https://user-images.githubusercontent.com/27782045/196541848-d33ebc3a-9e28-480c-a901-ca26421b320c.png)

iPad:
![image](https://user-images.githubusercontent.com/27782045/196541932-e1182c4e-fc37-44da-8dbb-7eb445d10886.png)
