### PR TITLE
Form transitions + caching + bugfixes

### DIFF
--- a/frontend/front/src/components/HeatPumpFade.js
+++ b/frontend/front/src/components/HeatPumpFade.js
@@ -1,0 +1,6 @@
+import React from "react";
+import { Fade } from "@mui/material";
+
+export const HeatPumpFade = ({ children, show }) => {
+  return show && <Fade in={show}>{children}</Fade>;
+};

--- a/frontend/front/src/components/HeatPumpSlide.js
+++ b/frontend/front/src/components/HeatPumpSlide.js
@@ -1,0 +1,12 @@
+import React from "react";
+import { Slide } from "@mui/material";
+
+export const HeatPumpSlide = ({ children, show }) => {
+  return (
+    show && (
+      <Slide in={show} direction="left">
+        {children}
+      </Slide>
+    )
+  );
+};

--- a/frontend/front/src/components/SurveyComponent/HeatPumpTextField.js
+++ b/frontend/front/src/components/SurveyComponent/HeatPumpTextField.js
@@ -22,6 +22,7 @@ export const HeatPumpTextField = ({
       }
       render={({ field }) => (
         <TextField
+          data-testId={name}
           label={label}
           variant="standard"
           error={!!formState.errors[name]}

--- a/frontend/front/src/components/SurveyComponent/SurveyComponent.js
+++ b/frontend/front/src/components/SurveyComponent/SurveyComponent.js
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  forwardRef,
+} from "react";
 import { useForm } from "react-hook-form";
 import { Button, Stack, Alert, CircularProgress, Box } from "@mui/material";
 import { HeatPumpDropdown } from "./HeatPumpDropdown";
@@ -11,217 +17,223 @@ import { useNavigate } from "react-router-dom";
 /*
  * Reusable survey component based on https://docs.google.com/document/d/1LPCNCUBJR8aOCEnO02x0YG3cPMg7CzThlnDzruU1KvI/edit
  */
-export const SurveyComponent = ({
-  submitSurvey,
-  isLoading,
-  activeHome,
-  isEditable,
-  surveyId,
-  formSpacing,
-  defaultData,
-  onDelete,
-}) => {
-  const navigate = useNavigate();
+export const SurveyComponent = forwardRef(
+  (
+    {
+      submitSurvey,
+      isLoading,
+      activeHome,
+      isEditable,
+      surveyId,
+      formSpacing,
+      defaultData,
+      onDelete,
+      style, // passed through so MUI transitions work
+    },
+    ref
+  ) => {
+    const navigate = useNavigate();
 
-  const { handleSubmit, reset, control } = useForm();
+    const { handleSubmit, reset, control } = useForm();
 
-  // TODO: id of the main survey goes here
-  const { data: surveyStructure, error: surveyStructureError } =
-    useGetSurveyStructureQuery(surveyId);
+    // TODO: id of the main survey goes here
+    const { data: surveyStructure, error: surveyStructureError } =
+      useGetSurveyStructureQuery(surveyId);
 
-  const formDefault = useMemo(() => {
-    if (defaultData) {
-      return defaultData;
-    }
+    const formDefault = useMemo(() => {
+      if (defaultData) {
+        return defaultData;
+      }
 
-    if (surveyStructure) {
-      return surveyStructure.survey_questions.reduce(
-        (prev, curr) => ({
-          ...prev,
-          [`${curr.id}`]: "",
-        }),
-        {}
-      );
-    }
+      if (surveyStructure) {
+        return surveyStructure.survey_questions.reduce(
+          (prev, curr) => ({
+            ...prev,
+            [`${curr.id}`]: "",
+          }),
+          {}
+        );
+      }
 
-    return null;
-  }, [defaultData, surveyStructure]);
+      return null;
+    }, [defaultData, surveyStructure]);
 
-  // useEffect to set the default data for the form
-  useEffect(() => {
-    if (formDefault) {
-      reset(formDefault);
-    }
-  }, [formDefault, reset]);
+    // useEffect to set the default data for the form
+    useEffect(() => {
+      if (formDefault) {
+        reset(formDefault);
+      }
+    }, [formDefault, reset]);
 
-  const [isEditing, setIsEditing] = useState(!isEditable);
+    const [isEditing, setIsEditing] = useState(!isEditable);
 
-  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
-  const isDisabled = useMemo(
-    () => isEditable && !isEditing,
-    [isEditing, isEditable]
-  );
+    const isDisabled = useMemo(
+      () => isEditable && !isEditing,
+      [isEditing, isEditable]
+    );
 
-  const commonButtonSection = useCallback(
-    () => (
-      <>
-        <Button variant="contained" type="submit">
-          {"Submit"}
-        </Button>
-        <Button
-          variant="outlined"
-          type="button"
-          onClick={(e) => {
-            e.preventDefault();
-            reset();
+    const commonButtonSection = useCallback(
+      () => (
+        <>
+          <Button variant="contained" type="submit">
+            {"Submit"}
+          </Button>
+          <Button
+            variant="outlined"
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              reset();
+            }}
+          >
+            {"Clear"}
+          </Button>
+        </>
+      ),
+      [reset]
+    );
+
+    const adminButtonsViewing = useCallback(
+      () => (
+        <>
+          <Button
+            type="button"
+            variant="contained"
+            onClick={(e) => {
+              e.preventDefault();
+              setIsEditing(true);
+            }}
+          >
+            {"EDIT"}
+          </Button>
+          <Button variant="outlined" type="button" onClick={() => navigate(-1)}>
+            {"BACK"}
+          </Button>
+          <Button
+            variant="outlined"
+            type="button"
+            color="error"
+            onClick={(e) => {
+              e.preventDefault();
+              setIsDeleteModalOpen(true);
+            }}
+          >
+            {"DELETE"}
+          </Button>
+        </>
+      ),
+      [navigate]
+    );
+
+    const adminButtonsEditing = useCallback(
+      () => (
+        <>
+          <Button variant="contained" type="submit">
+            {"SAVE"}
+          </Button>
+          <Button
+            variant="outlined"
+            type="button"
+            color="error"
+            onClick={(e) => {
+              e.preventDefault();
+              reset();
+              setIsEditing(false);
+            }}
+          >
+            {"CANCEL"}
+          </Button>
+        </>
+      ),
+      [reset]
+    );
+
+    const renderSurvey = useCallback(
+      () => (
+        <>
+          {surveyStructure?.survey_questions.map((q) => {
+            switch (q.response_type) {
+              case "radio":
+                return (
+                  <HeatPumpDropdown
+                    control={control}
+                    name={`${q.id}`}
+                    label={q.text}
+                    options={q.response_options.map((o) => ({
+                      value: o,
+                      label: o,
+                    }))}
+                    disabled={isDisabled}
+                  />
+                );
+              case "text":
+                return (
+                  <HeatPumpTextField
+                    control={control}
+                    name={`${q.id}`}
+                    label={q.text}
+                    disabled={isDisabled}
+                  />
+                );
+              default:
+                return (
+                  <Alert severity="error">{`Invalid question type: ${q.response_type}`}</Alert>
+                );
+            }
+          })}
+        </>
+      ),
+      [control, isDisabled, surveyStructure?.survey_questions]
+    );
+
+    return (
+      <div ref={ref} style={style}>
+        <ConfirmationModal
+          isOpen={isDeleteModalOpen}
+          handleConfirm={() => {
+            if (onDelete) {
+              onDelete();
+            }
           }}
-        >
-          {"Clear"}
-        </Button>
-      </>
-    ),
-    [reset]
-  );
-
-  const adminButtonsViewing = useCallback(
-    () => (
-      <>
-        <Button
-          type="button"
-          variant="contained"
-          onClick={(e) => {
-            e.preventDefault();
-            setIsEditing(true);
-          }}
-        >
-          {"EDIT"}
-        </Button>
-        <Button variant="outlined" type="button" onClick={() => navigate(-1)}>
-          {"BACK"}
-        </Button>
-        <Button
-          variant="outlined"
-          type="button"
-          color="error"
-          onClick={(e) => {
-            e.preventDefault();
-            setIsDeleteModalOpen(true);
-          }}
-        >
-          {"DELETE"}
-        </Button>
-      </>
-    ),
-    [navigate]
-  );
-
-  const adminButtonsEditing = useCallback(
-    () => (
-      <>
-        <Button variant="contained" type="submit">
-          {"SAVE"}
-        </Button>
-        <Button
-          variant="outlined"
-          type="button"
-          color="error"
-          onClick={(e) => {
-            e.preventDefault();
-            reset();
-            setIsEditing(false);
-          }}
-        >
-          {"CANCEL"}
-        </Button>
-      </>
-    ),
-    [reset]
-  );
-
-  const renderSurvey = useCallback(
-    () => (
-      <>
-        {surveyStructure?.survey_questions.map((q) => {
-          switch (q.response_type) {
-            case "radio":
-              return (
-                <HeatPumpDropdown
-                  control={control}
-                  name={`${q.id}`}
-                  label={q.text}
-                  options={q.response_options.map((o) => ({
-                    value: o,
-                    label: o,
-                  }))}
-                  disabled={isDisabled}
-                />
-              );
-            case "text":
-              return (
-                <HeatPumpTextField
-                  control={control}
-                  name={`${q.id}`}
-                  label={q.text}
-                  disabled={isDisabled}
-                />
-              );
-            default:
-              return (
-                <Alert severity="error">{`Invalid question type: ${q.response_type}`}</Alert>
-              );
-          }
-        })}
-      </>
-    ),
-    [control, isDisabled, surveyStructure?.survey_questions]
-  );
-
-  return (
-    <>
-      <ConfirmationModal
-        isOpen={isDeleteModalOpen}
-        handleConfirm={() => {
-          if (onDelete) {
-            onDelete();
-          }
-        }}
-        handleCancel={() => setIsDeleteModalOpen(false)}
-        confirmBtnText="Delete"
-        cancelBtnText="Cancel"
-        title="Confirm Delete"
-        message={`Are you sure you want to delete this survey data?`}
-      />
-      <AddressComponent home={activeHome} />
-      <form
-        onSubmit={handleSubmit((surveyData) =>
-          submitSurvey(surveyData, surveyId)
-        )}
-      >
-        <Stack spacing={formSpacing} mb={formSpacing} mt={formSpacing}>
-          {surveyStructure ? (
-            renderSurvey()
-          ) : surveyStructureError ? (
-            <Alert severity="error">
-              {"Encountered an error while loading the survey."}
-            </Alert>
-          ) : !activeHome ? (
-            <Alert severity="error">{"No active home set!"}</Alert>
-          ) : (
-            <Box display="flex" justifyContent="center">
-              <CircularProgress />
-            </Box>
+          handleCancel={() => setIsDeleteModalOpen(false)}
+          confirmBtnText="Delete"
+          cancelBtnText="Cancel"
+          title="Confirm Delete"
+          message={`Are you sure you want to delete this survey data?`}
+        />
+        <AddressComponent home={activeHome} />
+        <form
+          onSubmit={handleSubmit((surveyData) =>
+            submitSurvey(surveyData, surveyId)
           )}
-          <Stack direction="row" justifyContent="center" spacing={2}>
-            {isLoading && <CircularProgress />}
-            {isEditable
-              ? isEditing
-                ? adminButtonsEditing()
-                : adminButtonsViewing()
-              : commonButtonSection()}
+        >
+          <Stack spacing={formSpacing} mb={formSpacing} mt={formSpacing}>
+            {surveyStructure ? (
+              renderSurvey()
+            ) : surveyStructureError ? (
+              <Alert severity="error">
+                {"Encountered an error while loading the survey."}
+              </Alert>
+            ) : !activeHome ? (
+              <Alert severity="error">{"No active home set!"}</Alert>
+            ) : (
+              <Box display="flex" justifyContent="center">
+                <CircularProgress />
+              </Box>
+            )}
+            <Stack direction="row" justifyContent="center" spacing={2}>
+              {isLoading && <CircularProgress />}
+              {isEditable
+                ? isEditing
+                  ? adminButtonsEditing()
+                  : adminButtonsViewing()
+                : commonButtonSection()}
+            </Stack>
           </Stack>
-        </Stack>
-      </form>
-    </>
-  );
-};
+        </form>
+      </div>
+    );
+  }
+);

--- a/frontend/front/src/components/SurveyComponent/SurveyComponent.js
+++ b/frontend/front/src/components/SurveyComponent/SurveyComponent.js
@@ -130,7 +130,14 @@ export const SurveyComponent = forwardRef(
     const adminButtonsEditing = useCallback(
       () => (
         <>
-          <Button variant="contained" type="submit">
+          <Button
+            variant="contained"
+            type="submit"
+            onClick={() => {
+              // no preventDefault here, we want to do the submit and ALSO setIsEditing(false)
+              setIsEditing(false);
+            }}
+          >
             {"SAVE"}
           </Button>
           <Button

--- a/frontend/front/src/pages/Admin/survey/SurveyProfile.js
+++ b/frontend/front/src/pages/Admin/survey/SurveyProfile.js
@@ -59,7 +59,6 @@ const SurveyProfile = () => {
   const onDelete = useCallback(() => {
     deleteSurveyVisit(surveyVisitId);
     navigate("/admin/survey");
-    navigate(0); // reload page to update data
   }, [deleteSurveyVisit, surveyVisitId, navigate]);
 
   return (

--- a/frontend/front/src/pages/Admin/survey/SurveyProfile.js
+++ b/frontend/front/src/pages/Admin/survey/SurveyProfile.js
@@ -42,14 +42,16 @@ const SurveyProfile = () => {
 
   const onSubmit = useCallback(
     async (responses, surveyId) => {
-      const body = {
-        responses,
-        surveyId,
-        homeId: surveyVisit?.homeId,
-        // TODO: probably remove this and handle on the back end
-        date: new Date().toISOString(),
-      };
-      putSurveyVisit({ id: surveyVisitId, body });
+      return await putSurveyVisit({
+        id: surveyVisitId,
+        body: {
+          responses,
+          surveyId,
+          homeId: surveyVisit?.homeId,
+          // TODO: probably remove this and handle on the back end
+          date: new Date().toISOString(),
+        },
+      });
     },
     [putSurveyVisit, surveyVisit?.homeId, surveyVisitId]
   );

--- a/frontend/front/src/pages/Admin/survey/SurveyProfile.js
+++ b/frontend/front/src/pages/Admin/survey/SurveyProfile.js
@@ -60,9 +60,12 @@ const SurveyProfile = () => {
     navigate(0); // reload page to update data
   }, [deleteSurveyVisit, surveyVisitId, navigate]);
 
-  const PageContent = useCallback(() => {
-    if (surveyVisit && houseData) {
-      return (
+  return (
+    <Container>
+      <Typography variant="h5" mt={2}>
+        {title}
+      </Typography>
+      {surveyVisit && houseData ? (
         <AdminSurvey
           defaultData={surveyVisit.responses}
           activeHome={houseData}
@@ -71,35 +74,13 @@ const SurveyProfile = () => {
           onDelete={onDelete}
           isLoading={isSurveyVisitPutLoading || isSurveyDeleteLoading}
         />
-      );
-    }
-
-    if (surveyVisitError || houseError) {
-      return <SurveyError />;
-    }
-
-    return (
-      <Box display="flex" justifyContent="center">
-        <CircularProgress />
-      </Box>
-    );
-  }, [
-    houseData,
-    houseError,
-    isSurveyDeleteLoading,
-    isSurveyVisitPutLoading,
-    onDelete,
-    onSubmit,
-    surveyVisit,
-    surveyVisitError,
-  ]);
-
-  return (
-    <Container>
-      <Typography variant="h5" mt={2}>
-        {title}
-      </Typography>
-      <PageContent />
+      ) : surveyVisitError || houseError ? (
+        <SurveyError />
+      ) : (
+        <Box display="flex" justifyContent="center">
+          <CircularProgress />
+        </Box>
+      )}
     </Container>
   );
 };

--- a/frontend/front/src/pages/Admin/survey/SurveyTable.js
+++ b/frontend/front/src/pages/Admin/survey/SurveyTable.js
@@ -32,11 +32,21 @@ const createTableData = (surveyVisitData, surveyStructureData, houseData) => {
 const SurveyTable = () => {
   const navigate = useNavigate();
 
-  const { data: surveyVisitData, error: surveyVisitError } =
-    useGetSurveyVisitsQuery();
-  const { data: houseData, error: houseError } = useGetHomesDataQuery();
-  const { data: surveyStructureData, error: surveyStructureError } =
-    useGetSurveyListQuery();
+  const {
+    data: surveyVisitData,
+    error: surveyVisitError,
+    isLoading: isSurveyVisitLoading,
+  } = useGetSurveyVisitsQuery();
+  const {
+    data: houseData,
+    error: houseError,
+    isLoading: isHouseDataLoading,
+  } = useGetHomesDataQuery();
+  const {
+    data: surveyStructureData,
+    error: surveyStructureError,
+    isLoading: isSurveyStructureLoading,
+  } = useGetSurveyListQuery();
 
   const tableData = useMemo(
     () =>
@@ -50,28 +60,28 @@ const SurveyTable = () => {
     navigate(`${row.id}`);
   };
 
-  if (tableData) {
+  if (isSurveyVisitLoading || isHouseDataLoading || isSurveyStructureLoading) {
     return (
-      <DataGrid
-        rows={tableData}
-        columns={COLUMNS}
-        pageSize={20}
-        rowsPerPageOptions={[20]}
-        disableSelectionOnClick
-        autoHeight
-        onRowClick={onRowClick}
-      />
+      <Box display="flex" justifyContent="center">
+        <CircularProgress />
+      </Box>
     );
   }
 
   if (surveyVisitError || houseError || surveyStructureError) {
-    <SurveyError />;
+    return <SurveyError />;
   }
 
   return (
-    <Box display="flex" justifyContent="center">
-      <CircularProgress />
-    </Box>
+    <DataGrid
+      rows={tableData}
+      columns={COLUMNS}
+      pageSize={20}
+      rowsPerPageOptions={[20]}
+      disableSelectionOnClick
+      autoHeight
+      onRowClick={onRowClick}
+    />
   );
 };
 

--- a/frontend/front/src/pages/Public/Components/AddressValidatorComponent.js
+++ b/frontend/front/src/pages/Public/Components/AddressValidatorComponent.js
@@ -1,42 +1,55 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { Stack, Button, CircularProgress, Box } from "@mui/material";
 import { HeatPumpAddressField } from "../../../components/SurveyComponent/HeatPumpAddressField";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 
-export const AddressValidatorComponent = ({ onValidate, isLoading }) => {
-  const navigate = useNavigate();
-
-  const { handleSubmit, control } = useForm({
-    defaultValues: {
-      address: { street: "", aptNumber: "", zipCode: "", city: "" },
+export const AddressValidatorComponent = forwardRef(
+  (
+    {
+      onValidate,
+      isLoading,
+      style, // passed through so MUI transitions work
     },
-  });
+    ref
+  ) => {
+    const navigate = useNavigate();
 
-  return (
-    <form onSubmit={handleSubmit((data) => onValidate(data))}>
-      <Box mx={{ margin: "1em 0" }}>
-        <HeatPumpAddressField
-          control={control}
-          label={"Enter the address where you're interested in a heat pump:"}
-        />
-      </Box>
-      <Stack direction="row" justifyContent="center" spacing={2}>
-        {isLoading && <CircularProgress />}
-        <Button variant="contained" type="submit">
-          {"Verify"}
-        </Button>
-        <Button
-          variant="outlined"
-          type="button"
-          color="warning"
-          onClick={() => {
-            navigate(-1);
-          }}
-        >
-          {"Back"}
-        </Button>
-      </Stack>
-    </form>
-  );
-};
+    const { handleSubmit, control } = useForm({
+      defaultValues: {
+        address: { street: "", aptNumber: "", zipCode: "", city: "" },
+      },
+    });
+
+    return (
+      <form
+        onSubmit={handleSubmit((data) => onValidate(data))}
+        ref={ref}
+        style={style}
+      >
+        <Box mx={{ margin: "1em 0" }}>
+          <HeatPumpAddressField
+            control={control}
+            label={"Enter the address where you're interested in a heat pump:"}
+          />
+        </Box>
+        <Stack direction="row" justifyContent="center" spacing={2}>
+          {isLoading && <CircularProgress />}
+          <Button variant="contained" type="submit">
+            {"Verify"}
+          </Button>
+          <Button
+            variant="outlined"
+            type="button"
+            color="warning"
+            onClick={() => {
+              navigate(-1);
+            }}
+          >
+            {"Back"}
+          </Button>
+        </Stack>
+      </form>
+    );
+  }
+);

--- a/frontend/front/src/pages/Public/Components/PublicSurvey.js
+++ b/frontend/front/src/pages/Public/Components/PublicSurvey.js
@@ -1,8 +1,13 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { SurveyComponent } from "../../../components/SurveyComponent/SurveyComponent";
 
 const PUBLIC_SURVEY_ID = "1";
 
-export const PublicSurvey = (props) => (
-  <SurveyComponent {...props} surveyId={PUBLIC_SURVEY_ID} formSpacing={5} />
-);
+export const PublicSurvey = forwardRef((props, ref) => (
+  <SurveyComponent
+    {...props}
+    surveyId={PUBLIC_SURVEY_ID}
+    formSpacing={5}
+    ref={ref}
+  />
+));

--- a/frontend/front/src/pages/Public/Components/ThanksForSubmission.js
+++ b/frontend/front/src/pages/Public/Components/ThanksForSubmission.js
@@ -1,11 +1,12 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { Alert, Button } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 
-export const ThanksForSubmission = () => {
+export const ThanksForSubmission = forwardRef((_, ref) => {
   const navigate = useNavigate();
   return (
     <Alert
+      ref={ref}
       severity="success"
       action={
         <Button
@@ -22,4 +23,4 @@ export const ThanksForSubmission = () => {
       {"Thank you for your submission!"}
     </Alert>
   );
-};
+});

--- a/frontend/front/src/pages/Public/Pages/SurveyPage.js
+++ b/frontend/front/src/pages/Public/Pages/SurveyPage.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { Alert, Container, Snackbar, Stack } from "@mui/material";
 import { AddressValidatorComponent } from "../Components/AddressValidatorComponent";
 import {
@@ -8,6 +8,12 @@ import {
 import { useGetReCAPTCHAToken } from "../../../components/ReCaptcha";
 import { ThanksForSubmission } from "../Components/ThanksForSubmission";
 import { PublicSurvey } from "../Components/PublicSurvey";
+import { HeatPumpSlide } from "../../../components/HeatPumpSlide";
+import { HeatPumpFade } from "../../../components/HeatPumpFade";
+
+const STEP_ADDRESS = "PHASE_ADDRESS";
+const STEP_SURVEY = "PHASE_SURVEY";
+const STEP_THANKS = "PHASE_THANKS";
 
 /*
  * Page that handles the lifecycle of the public survey process
@@ -58,6 +64,15 @@ export const SurveyPage = () => {
     [addSurveyVisit, createHomeData?.id, getReCaptchaToken]
   );
 
+  const step = useMemo(() => {
+    if (!createHomeData && !isSurveyVisitSuccess) {
+      return STEP_ADDRESS;
+    } else if (isSurveyVisitSuccess) {
+      return STEP_THANKS;
+    }
+    return STEP_SURVEY;
+  }, [createHomeData, isSurveyVisitSuccess]);
+
   return (
     <Container>
       <Stack direction="column" alignItems="center" justifyContent="center">
@@ -71,20 +86,22 @@ export const SurveyPage = () => {
           the installation process.
         </p>
       </Stack>
-      {!createHomeData && !isSurveyVisitSuccess ? (
+      <HeatPumpFade show={step === STEP_ADDRESS}>
         <AddressValidatorComponent
           onValidate={handleCreateHome}
           isLoading={isCreateHomeLoading}
         />
-      ) : isSurveyVisitSuccess ? (
-        <ThanksForSubmission />
-      ) : (
+      </HeatPumpFade>
+      <HeatPumpSlide show={step === STEP_SURVEY}>
         <PublicSurvey
           submitSurvey={handleAddSurveyVisit}
           isLoading={isSurveyVisitLoading}
           activeHome={createHomeData}
         />
-      )}
+      </HeatPumpSlide>
+      <HeatPumpSlide show={step === STEP_THANKS}>
+        <ThanksForSubmission />
+      </HeatPumpSlide>
       {/* TODO: this should probably be a more specific error */}
       <Snackbar open={!!createHomeError}>
         <Alert severity="info">

--- a/frontend/front/src/pages/Public/Pages/SurveyPage.js
+++ b/frontend/front/src/pages/Public/Pages/SurveyPage.js
@@ -52,7 +52,7 @@ export const SurveyPage = () => {
   const handleAddSurveyVisit = useCallback(
     async (responses, surveyId) => {
       const recaptcha = await getReCaptchaToken();
-      addSurveyVisit({
+      return await addSurveyVisit({
         responses,
         recaptcha,
         surveyId,

--- a/frontend/front/src/pages/Surveyor/Components/SubmissionSuccess.js
+++ b/frontend/front/src/pages/Surveyor/Components/SubmissionSuccess.js
@@ -1,26 +1,29 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { Alert, Button } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 
-export const SubmissionSuccess = ({ submissionId, surveyId }) => {
-  const navigate = useNavigate();
-  return (
-    <Alert
-      sx={{ margin: "1em" }}
-      severity="success"
-      action={
-        <Button
-          color="inherit"
-          size="small"
-          onClick={() => {
-            navigate("/surveyor/dashboard");
-          }}
-        >
-          {"dashboard"}
-        </Button>
-      }
-    >
-      {`Successfully submitted submission '${submissionId}' for survey '${surveyId}'`}
-    </Alert>
-  );
-};
+export const SubmissionSuccess = forwardRef(
+  ({ submissionId, surveyId }, ref) => {
+    const navigate = useNavigate();
+    return (
+      <Alert
+        ref={ref}
+        sx={{ margin: "1em" }}
+        severity="success"
+        action={
+          <Button
+            color="inherit"
+            size="small"
+            onClick={() => {
+              navigate("/surveyor/dashboard");
+            }}
+          >
+            {"dashboard"}
+          </Button>
+        }
+      >
+        {`Successfully submitted submission '${submissionId}' for survey '${surveyId}'`}
+      </Alert>
+    );
+  }
+);

--- a/frontend/front/src/pages/Surveyor/Components/SurveyorSurvey.js
+++ b/frontend/front/src/pages/Surveyor/Components/SurveyorSurvey.js
@@ -1,7 +1,12 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { SurveyComponent } from "../../../components/SurveyComponent/SurveyComponent";
 
 export const SURVEYOR_SURVEY_ID = "2";
-export const SurveyorSurvey = (props) => (
-  <SurveyComponent {...props} surveyId={SURVEYOR_SURVEY_ID} formSpacing={2} />
-);
+export const SurveyorSurvey = forwardRef((props, ref) => (
+  <SurveyComponent
+    {...props}
+    surveyId={SURVEYOR_SURVEY_ID}
+    formSpacing={2}
+    ref={ref}
+  />
+));

--- a/frontend/front/src/pages/Surveyor/houseProfile/HouseProfile.js
+++ b/frontend/front/src/pages/Surveyor/houseProfile/HouseProfile.js
@@ -40,8 +40,8 @@ const HouseProfile = () => {
   ] = usePostSurveyVisitMutation();
 
   const submitSurvey = useCallback(
-    (responses, surveyId) => {
-      addSurveyVisit({
+    async (responses, surveyId) => {
+      return await addSurveyVisit({
         responses,
         homeId,
         surveyId,

--- a/frontend/front/src/redux/apiSlice.js
+++ b/frontend/front/src/redux/apiSlice.js
@@ -15,7 +15,7 @@ export const apiSlice = createApi({
   //   headers.set("apiKey", "TOKEN");
   //   return headers;
   // },
-  tagTypes: ["Home"],
+  tagTypes: ["Home", "SurveyVisit"],
   endpoints: (builder) => ({
     //Home section of the slice
     getHomesData: builder.query({
@@ -107,12 +107,20 @@ export const apiSlice = createApi({
         method: "post",
         body,
       }),
+      invalidatesTags: ["SurveyVisit"],
     }),
     getSurveyVisits: builder.query({
       query: () => ({ url: "/homesurvey", method: "get" }),
+      providesTags: (result = []) => [
+        "SurveyVisit",
+        ...result.map(({ id }) => ({ type: "SurveyVisit", id })),
+      ],
     }),
     getSurveyVisit: builder.query({
       query: (id) => ({ url: `/homesurvey/${id}`, method: "get" }),
+      providesTags: (result = [], error, arg) => [
+        { type: "SurveyVisit", id: arg },
+      ],
     }),
     putSurveyVisit: builder.mutation({
       query: ({ id, body }) => {
@@ -122,12 +130,18 @@ export const apiSlice = createApi({
           body,
         };
       },
+      invalidatesTags: (result, error, arg) => [
+        { type: "SurveyVisit", id: arg.id },
+      ],
     }),
     deleteSurveyVisit: builder.mutation({
       query: (id) => ({
         url: `/homesurvey/${id}`,
         method: "delete",
       }),
+      invalidatesTags: (result, error, arg) => [
+        { type: "SurveyVisit", id: arg.id },
+      ],
     }),
   }),
 });

--- a/frontend/front/src/util/surveyUtils.js
+++ b/frontend/front/src/util/surveyUtils.js
@@ -1,0 +1,11 @@
+export const buildSurveyCacheKey = (surveyId, homeId) =>
+  `survey${surveyId}-home${homeId}`;
+
+export const buildDefaultDataFromSurveyStructure = (surveyStructure) =>
+  surveyStructure.survey_questions.reduce(
+    (prev, curr) => ({
+      ...prev,
+      [`${curr.id}`]: "",
+    }),
+    {}
+  );


### PR DESCRIPTION
* added visual transitions between steps of each form
* fixed survey data not displaying properly after editing in admin view
* cache incomplete surveys in local storage until theyre submitted
* refresh list of survey visits with tag invalidation instead of reloading the page :sweat_smile: 