### PR TITLE
Add geocodes to assignments model

### DIFF
--- a/backend/app/controllers/assignments_controller.rb
+++ b/backend/app/controllers/assignments_controller.rb
@@ -65,7 +65,7 @@ class AssignmentsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def assignment_params
-    params.require(:assignment).permit(:group, :region_code)
+    params.require(:assignment).permit(:group, :region_code, :geocode)
   end
 
   def search_params

--- a/backend/app/views/assignments/_assignment.json.jbuilder
+++ b/backend/app/views/assignments/_assignment.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.extract! assignment, :id, :group, :region_code
+json.extract! assignment, :id, :group, :region_code, :geocode
 
 json.surveyor_ids do
   json.array!(assignment.surveyors.map { |s| s[:id] })

--- a/backend/db/migrate/20230509010102_add_geocode_to_assignment.rb
+++ b/backend/db/migrate/20230509010102_add_geocode_to_assignment.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGeocodeToAssignment < ActiveRecord::Migration[7.0]
+  def change
+    add_column :assignments, :geocode, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_19_144022) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_09_010102) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_19_144022) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "region_code"
+    t.string "geocode"
   end
 
   create_table "assignments_surveyors", id: false, force: :cascade do |t|

--- a/backend/lib/seeds/test_assignments.csv
+++ b/backend/lib/seeds/test_assignments.csv
@@ -1,8 +1,8 @@
-group,region_code,surveyor_email
-"A1",1,"alice.abbott@test.com"
-"A2",1,"alice.abbott@test.com"
-"B",2,"bob.baker@test.com"
-"C",2,"charlotte.cooke@test.com"
-"D",2,"david.daley@test.com"
-"E1",3,"eve.earl@test.com"
-"E2",3,"eve.earl@test.com"
+group,region_code,geocode,surveyor_email
+"A1",1,"42.35493388720329, -71.07422031985483","alice.abbott@test.com"
+"A2",1,"42.364389744746916, -71.05387467871688","alice.abbott@test.com"
+"B",2,"42.349812944064155, -71.07827431974506","bob.baker@test.com"
+"C",2,"42.346832161360226, -71.09887315954676","charlotte.cooke@test.com"
+"D",2,"42.355290032901124, -71.05643327261072","david.daley@test.com"
+"E1",3,"42.30761689852922, -71.05838999633616","eve.earl@test.com"
+"E2",3,"42.3515931979639, -71.12065244008181","eve.earl@test.com"


### PR DESCRIPTION
Closes #273 

This adds a single column for geocode to the assignment model.