### PR TITLE
Allow passing replacement surveyor_ids on assignments update

### DIFF
--- a/backend/app/controllers/assignments_controller.rb
+++ b/backend/app/controllers/assignments_controller.rb
@@ -65,7 +65,7 @@ class AssignmentsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def assignment_params
-    params.require(:assignment).permit(:group, :region_code, :geocode)
+    params.require(:assignment).permit(:group, :region_code, :geocode, surveyor_ids: [])
   end
 
   def search_params

--- a/backend/spec/requests/assignments_spec.rb
+++ b/backend/spec/requests/assignments_spec.rb
@@ -14,6 +14,7 @@ require 'rails_helper'
 # of tools you can use to make these specs even more expressive, but we're
 # sticking to rails and rspec-rails APIs to keep things simple and stable.
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe '/assignments', type: :request do
   # This should return the minimal set of attributes required to create a valid
   # Assignment. As you add validations to Assignment, be sure to
@@ -108,21 +109,17 @@ RSpec.describe '/assignments', type: :request do
   describe 'PATCH /update' do
     context 'with valid parameters' do
       let(:new_attributes) do
-        skip('Add a hash of attributes valid for your model')
+        {
+          surveyor_ids: []
+        }
       end
 
-      it 'updates the requested assignment' do
+      it 'updates the assignment' do
         assignment = Assignment.create! valid_attributes
         patch assignment_url(assignment), params: { assignment: new_attributes }, as: :json
         assignment.reload
-        skip('Add assertions for updated state')
-      end
-
-      it 'redirects to the assignment' do
-        assignment = Assignment.create! valid_attributes
-        patch assignment_url(assignment), params: { assignment: new_attributes }, as: :json
-        assignment.reload
-        expect(response).to redirect_to(assignment_url(assignment))
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)['surveyor_ids']).to match_array([])
       end
     end
 
@@ -147,3 +144,4 @@ RSpec.describe '/assignments', type: :request do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/backend/spec/requests/assignments_spec.rb
+++ b/backend/spec/requests/assignments_spec.rb
@@ -14,7 +14,6 @@ require 'rails_helper'
 # of tools you can use to make these specs even more expressive, but we're
 # sticking to rails and rspec-rails APIs to keep things simple and stable.
 
-# rubocop:disable Metrics/BlockLength
 RSpec.describe '/assignments', type: :request do
   # This should return the minimal set of attributes required to create a valid
   # Assignment. As you add validations to Assignment, be sure to
@@ -144,4 +143,3 @@ RSpec.describe '/assignments', type: :request do
     end
   end
 end
-# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Parse new surveyor_ids when passed for `PUT` to `/assignments/<id>`.