### PR TITLE
Leo westebbe/issue 365 load surveyor survey

### DIFF
--- a/frontend/front/src/api/apiSlice.js
+++ b/frontend/front/src/api/apiSlice.js
@@ -108,7 +108,7 @@ export const apiSlice = createApi({
 
     /* Survey Endpoints */
     getSurveys: builder.query({
-      query: () => ({ url: "/surveys", method: "GET" }),
+      query: () => ({ url: "/surveys.json", method: "GET" }),
       transformResponse: (res) => res.sort(sortById),
       providesTags: (result = [], error, arg) => [
         "Survey",

--- a/frontend/front/src/api/apiSlice.js
+++ b/frontend/front/src/api/apiSlice.js
@@ -117,7 +117,7 @@ export const apiSlice = createApi({
     }),
     getSurveyStructure: builder.query({
       query: (id) => ({
-        url: `/surveys/${id}`,
+        url: `/surveys/${id}.json`,
         method: "GET",
       }),
       providesTags: (result, error, arg) => [{ type: "Survey", id: arg }],

--- a/frontend/front/src/pages/Surveyor/Components/SurveyorSurvey.js
+++ b/frontend/front/src/pages/Surveyor/Components/SurveyorSurvey.js
@@ -1,7 +1,7 @@
 import React, { forwardRef } from "react";
 import SurveyComponent from "../../../components/SurveyComponent/SurveyComponent";
 
-export const SURVEYOR_SURVEY_ID = "2";
+export const SURVEYOR_SURVEY_ID = "1";
 export const SurveyorSurvey = forwardRef((props, ref) => (
   <SurveyComponent
     {...props}


### PR DESCRIPTION
In response to issue #365.

Clicking an incomplete home loads Survey 1 and the data for the associated home.

I'm not clear if there should be a capability to load a different survey - there are 4 on the server, but only survey with `id: 1` has any data in the `survey_questions` array. Outside of this branch, the `SurveyorSurvey` component loads survey with `id: 2`, but that one is blank.