### PR TITLE
Include unit number for addresses on surveyor dashboard view

### DIFF
--- a/frontend/front/src/pages/Surveyor/dashboard/AssignmentUnit.js
+++ b/frontend/front/src/pages/Surveyor/dashboard/AssignmentUnit.js
@@ -166,6 +166,7 @@ const AssignmentUnit = (props) => {
                   primary={
                     <Box>
                       <Box>{`${value.street_number} ${value.street_name}`}</Box>
+                      {value?.unit_number && <Box>{`Unit ${value.unit_number}`}</Box>}
                       <Box>{`${value.city} ${value.zip_code}`}</Box>
                       <Box>
                         {value.completed ? (


### PR DESCRIPTION
Addresses on the dashboard view should display unit number to allow surveyor to distinguish from other units at the same address.