### PR TITLE
Remove no-longer-need .json suffix from /surveys apiSlice endpoints

### DIFF
--- a/frontend/front/src/api/apiSlice.js
+++ b/frontend/front/src/api/apiSlice.js
@@ -108,7 +108,7 @@ export const apiSlice = createApi({
 
     /* Survey Endpoints */
     getSurveys: builder.query({
-      query: () => ({ url: "/surveys.json", method: "GET" }),
+      query: () => ({ url: "/surveys", method: "GET" }),
       transformResponse: (res) => res.sort(sortById),
       providesTags: (result = [], error, arg) => [
         "Survey",
@@ -117,7 +117,7 @@ export const apiSlice = createApi({
     }),
     getSurveyStructure: builder.query({
       query: (id) => ({
-        url: `/surveys/${id}.json`,
+        url: `/surveys/${id}`,
         method: "GET",
       }),
       providesTags: (result, error, arg) => [{ type: "Survey", id: arg }],


### PR DESCRIPTION
We no longer need to include the `'.json' suffix for these endpoints because @mikelynch updated the backend `/surveys` endpoints to deliver straight json (#380).