### PR TITLE
Leo westebbe/frontend 334 submit survey

### DIFF
--- a/frontend/front/src/api/apiSlice.js
+++ b/frontend/front/src/api/apiSlice.js
@@ -160,11 +160,15 @@ export const apiSlice = createApi({
       providesTags: (result, error, arg) => [{ type: "SurveyVisit", id: arg }],
     }),
     createSurveyVisit: builder.mutation({
-      query: (surveyVisit) => ({
-        url: "/survey_visits",
-        method: "POST",
-        body: surveyVisit,
-      }),
+      query: ({ surveyVisit, recaptcha }) => {
+        const { surveyor_id } = surveyVisit.survey_visit;
+        return {
+          url: "/survey_visits",
+          method: "POST",
+          body: surveyVisit,
+          headers: surveyor_id === null && [[`Recaptcha-Token`, recaptcha]],
+        };
+      },
       invalidatesTags: ["SurveyVisit"],
     }),
     updateSurveyVisit: builder.mutation({

--- a/frontend/front/src/api/apiSlice.js
+++ b/frontend/front/src/api/apiSlice.js
@@ -160,15 +160,13 @@ export const apiSlice = createApi({
       providesTags: (result, error, arg) => [{ type: "SurveyVisit", id: arg }],
     }),
     createSurveyVisit: builder.mutation({
-      query: ({ surveyVisit, recaptcha }) => {
-        const { surveyor_id } = surveyVisit.survey_visit;
-        return {
-          url: "/survey_visits",
+      query: ({ surveyVisit, recaptcha }) => (
+          {url: "/survey_visits",
           method: "POST",
           body: surveyVisit,
-          headers: [[`Recaptcha-Token`, recaptcha]],
-        };
-      },
+          headers: [[`Recaptcha-Token`, recaptcha]]}
+        )
+      ,
       invalidatesTags: ["SurveyVisit"],
     }),
     updateSurveyVisit: builder.mutation({

--- a/frontend/front/src/api/apiSlice.js
+++ b/frontend/front/src/api/apiSlice.js
@@ -166,7 +166,7 @@ export const apiSlice = createApi({
           url: "/survey_visits",
           method: "POST",
           body: surveyVisit,
-          headers: surveyor_id === null && [[`Recaptcha-Token`, recaptcha]],
+          headers: [[`Recaptcha-Token`, recaptcha]],
         };
       },
       invalidatesTags: ["SurveyVisit"],

--- a/frontend/front/src/components/SurveyComponent/SurveyComponent.js
+++ b/frontend/front/src/components/SurveyComponent/SurveyComponent.js
@@ -185,7 +185,12 @@ const SurveyComponent = ({
       <AddressComponent home={activeHome} />
       <form
         onSubmit={handleSubmit(async (surveyData) => {
-          const { data } = await submitSurvey(surveyData, surveyId, clearCache);
+          const { data } = await submitSurvey(
+            surveyData,
+            surveyId,
+            activeHome,
+            clearCache
+          );
           if (!!data) {
             // clear cache data if survey submission succeeds
             clearCache();

--- a/frontend/front/src/components/SurveyComponent/SurveyComponent.js
+++ b/frontend/front/src/components/SurveyComponent/SurveyComponent.js
@@ -269,19 +269,22 @@ const SurveyComponentWrapper = forwardRef((props, ref) => {
     return null;
   }, [defaultData, surveyStructure]);
 
-  if (isSurveyLoading) {
-    return <Loader />;
-  }
   return (
     <div ref={ref} style={style}>
-      {surveyStructure && formDefault && activeHome ? (
-        <SurveyComponent
-          {...props}
-          surveyStructure={surveyStructure}
-          formDefault={formDefault}
-        />
+      {isSurveyLoading ? (
+        <Loader />
+      ) : isSurveyError ? (
+        <SurveyError />
       ) : (
-        isSurveyError && <SurveyError />
+        surveyStructure &&
+        formDefault &&
+        activeHome && (
+          <SurveyComponent
+            {...props}
+            surveyStructure={surveyStructure}
+            formDefault={formDefault}
+          />
+        )
       )}
     </div>
   );

--- a/frontend/front/src/pages/Public/Components/PublicSurvey.js
+++ b/frontend/front/src/pages/Public/Components/PublicSurvey.js
@@ -4,10 +4,12 @@ import SurveyComponent from "../../../components/SurveyComponent/SurveyComponent
 const PUBLIC_SURVEY_ID = "1";
 
 export const PublicSurvey = forwardRef((props, ref) => (
-  <SurveyComponent
-    {...props}
-    surveyId={PUBLIC_SURVEY_ID}
-    formSpacing={5}
-    ref={ref}
-  />
+  <div ref={ref}>
+    <SurveyComponent
+      {...props}
+      surveyId={PUBLIC_SURVEY_ID}
+      formSpacing={5}
+      ref={ref}
+    />
+  </div>
 ));

--- a/frontend/front/src/pages/Public/Pages/SurveyPage.js
+++ b/frontend/front/src/pages/Public/Pages/SurveyPage.js
@@ -57,18 +57,34 @@ export const SurveyPage = () => {
   );
 
   const handleAddSurveyVisit = useCallback(
-    async (responses, surveyId) => {
-      const recaptcha = await getReCaptchaToken();
-      return await addSurveyVisit({
-        responses,
-        recaptcha,
-        surveyId,
-        homeId: createHomeData?.id,
-        // TODO: probably remove this and handle on the back end
-        date: new Date().toISOString(),
+    async (responses, surveyId, activeHome) => {
+      const recaptcha = await getReCaptchaToken("create_survey");
+
+      const surveyAnswers = {};
+      Object.entries(responses).forEach(([key, value]) => {
+        surveyAnswers[key] = {
+          survey_question_id: key,
+          answer: value,
+        };
       });
+
+      const surveyVisit = await addSurveyVisit({
+        surveyVisit: {
+          survey_visit: {
+            home_id: activeHome.id,
+            surveyor_id: null,
+            survey_response_attributes: {
+              survey_id: surveyId,
+              completed: "true",
+              survey_answers_attributes: surveyAnswers,
+            },
+          },
+        },
+        recaptcha,
+      });
+      return surveyVisit;
     },
-    [addSurveyVisit, createHomeData?.id, getReCaptchaToken]
+    [addSurveyVisit, getReCaptchaToken]
   );
 
   const step = useMemo(() => {

--- a/frontend/front/src/pages/Surveyor/Components/SurveyorSurvey.js
+++ b/frontend/front/src/pages/Surveyor/Components/SurveyorSurvey.js
@@ -3,12 +3,10 @@ import SurveyComponent from "../../../components/SurveyComponent/SurveyComponent
 
 export const SURVEYOR_SURVEY_ID = "1";
 export const SurveyorSurvey = forwardRef((props, ref) => (
-  <div ref={ref}>
-    <SurveyComponent
-      {...props}
-      surveyId={SURVEYOR_SURVEY_ID}
-      formSpacing={2}
-      ref={ref}
-    />
-  </div>
+  <SurveyComponent
+    {...props}
+    surveyId={SURVEYOR_SURVEY_ID}
+    formSpacing={2}
+    ref={ref}
+  />
 ));

--- a/frontend/front/src/pages/Surveyor/Components/SurveyorSurvey.js
+++ b/frontend/front/src/pages/Surveyor/Components/SurveyorSurvey.js
@@ -3,10 +3,12 @@ import SurveyComponent from "../../../components/SurveyComponent/SurveyComponent
 
 export const SURVEYOR_SURVEY_ID = "1";
 export const SurveyorSurvey = forwardRef((props, ref) => (
-  <SurveyComponent
-    {...props}
-    surveyId={SURVEYOR_SURVEY_ID}
-    formSpacing={2}
-    ref={ref}
-  />
+  <div ref={ref}>
+    <SurveyComponent
+      {...props}
+      surveyId={SURVEYOR_SURVEY_ID}
+      formSpacing={2}
+      ref={ref}
+    />
+  </div>
 ));

--- a/frontend/front/src/pages/Surveyor/houseProfile/HouseProfile.js
+++ b/frontend/front/src/pages/Surveyor/houseProfile/HouseProfile.js
@@ -1,9 +1,4 @@
-import {
-  Alert,
-  Container,
-
-  Snackbar,
-} from "@mui/material";
+import { Alert, Container, Snackbar } from "@mui/material";
 import React, { useCallback, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import { HeatPumpSlide } from "../../../components/HeatPumpSlide";
@@ -29,8 +24,8 @@ const HouseProfile = () => {
   const { id: homeId } = useParams();
   const {
     data: homeData,
-    error: homesError,
-    isLoading: isHomesLoading,
+    error: homeError,
+    isLoading: isHomeLoading,
   } = useGetHomeQuery(homeId);
   const assignmentId = homeData?.assignment_id;
 
@@ -39,6 +34,7 @@ const HouseProfile = () => {
     isError: isAssignmentError,
     isLoading: isAssignmentLoading,
   } = useGetAssignmentQuery(assignmentId);
+  const surveyorIds = assignmentData?.surveyor_ids;
 
   const [
     addSurveyVisit,
@@ -61,13 +57,15 @@ const HouseProfile = () => {
       });
 
       const surveyVisit = await addSurveyVisit({
-        survey_visit: {
-          home_id: homeId,
-          surveyor_id: "1",
-          survey_response_attributes: {
-            survey_id: surveyId,
-            completed: "true",
-            survey_answers_attributes: surveyAnswers,
+        surveyVisit: {
+          survey_visit: {
+            home_id: homeId,
+            surveyor_id: surveyorIds[0],
+            survey_response_attributes: {
+              survey_id: surveyId,
+              completed: "true",
+              survey_answers_attributes: surveyAnswers,
+            },
           },
         },
       });
@@ -77,7 +75,7 @@ const HouseProfile = () => {
   );
 
   const step = useMemo(() => {
-    if (isHomesLoading) {
+    if (isHomeLoading || isAssignmentLoading) {
       return STEP_LOADING;
     } else if (!homeData) {
       return STEP_HOME_ERROR;
@@ -85,7 +83,7 @@ const HouseProfile = () => {
       return STEP_THANKS;
     }
     return STEP_SURVEY;
-  }, [homeData, isHomesLoading, isSurveyVisitSuccess]);
+  }, [homeData, isAssignmentLoading, isHomeLoading, isSurveyVisitSuccess]);
 
   return (
     <Container>
@@ -99,7 +97,7 @@ const HouseProfile = () => {
       <HeatPumpFade show={step === STEP_SURVEY}>
         <SurveyorSurvey
           submitSurvey={submitSurvey}
-          isLoading={isHomesLoading || isSurveyVisitLoading}
+          isLoading={isHomeLoading || isSurveyVisitLoading}
           activeHome={homeData}
         />
       </HeatPumpFade>
@@ -112,8 +110,11 @@ const HouseProfile = () => {
       <Snackbar open={!!surveyVisitError}>
         <Alert severity="error">{"Error submitting survey."}</Alert>
       </Snackbar>
-      <Snackbar open={!!homesError}>
+      <Snackbar open={!!homeError}>
         <Alert severity="error">{"Error retrieving home data."}</Alert>
+      </Snackbar>
+      <Snackbar open={isAssignmentError}>
+        <Alert severity="error">{"Error retrieving assignment data."}</Alert>
       </Snackbar>
     </Container>
   );

--- a/frontend/front/src/pages/Surveyor/houseProfile/HouseProfile.js
+++ b/frontend/front/src/pages/Surveyor/houseProfile/HouseProfile.js
@@ -10,7 +10,7 @@ import { HeatPumpSlide } from "../../../components/HeatPumpSlide";
 import { HeatPumpFade } from "../../../components/HeatPumpFade";
 import {
   useGetHomeQuery,
-  useCreateSurveyVisitMutation
+  useCreateSurveyVisitMutation,
 } from "../../../api/apiSlice";
 import { SubmissionSuccess } from "../Components/SubmissionSuccess";
 import {
@@ -58,7 +58,7 @@ const HouseProfile = () => {
           surveyor_id: "1",
           survey_response_attributes: {
             survey_id: surveyId,
-            completed: true,
+            completed: "true",
             survey_answers_attributes: surveyAnswers,
           },
         },

--- a/frontend/front/src/pages/Surveyor/houseProfile/HouseProfile.js
+++ b/frontend/front/src/pages/Surveyor/houseProfile/HouseProfile.js
@@ -27,14 +27,15 @@ const HouseProfile = () => {
     error: homeError,
     isLoading: isHomeLoading,
   } = useGetHomeQuery(homeId);
-  const assignmentId = homeData?.assignment_id;
+  // const assignmentId = homeData?.assignment_id;
 
-  const {
-    data: assignmentData,
-    isError: isAssignmentError,
-    isLoading: isAssignmentLoading,
-  } = useGetAssignmentQuery(assignmentId);
-  const surveyorIds = assignmentData?.surveyor_ids;
+  // const {
+  //   data: assignmentData,
+  //   isError: isAssignmentError,
+  //   isLoading: isAssignmentLoading,
+  // } = useGetAssignmentQuery(assignmentId);
+  // const surveyorId = assignmentData?.surveyor_ids[0];
+  // console.log(surveyorId);
 
   const [
     addSurveyVisit,
@@ -60,7 +61,7 @@ const HouseProfile = () => {
         surveyVisit: {
           survey_visit: {
             home_id: homeId,
-            surveyor_id: surveyorIds[0],
+            surveyor_id: 1,
             survey_response_attributes: {
               survey_id: surveyId,
               completed: "true",
@@ -75,7 +76,10 @@ const HouseProfile = () => {
   );
 
   const step = useMemo(() => {
-    if (isHomeLoading || isAssignmentLoading) {
+    if (
+      isHomeLoading
+      // || isAssignmentLoading
+    ) {
       return STEP_LOADING;
     } else if (!homeData) {
       return STEP_HOME_ERROR;
@@ -83,7 +87,12 @@ const HouseProfile = () => {
       return STEP_THANKS;
     }
     return STEP_SURVEY;
-  }, [homeData, isAssignmentLoading, isHomeLoading, isSurveyVisitSuccess]);
+  }, [
+    homeData,
+    // isAssignmentLoading,
+    isHomeLoading,
+    isSurveyVisitSuccess,
+  ]);
 
   return (
     <Container>
@@ -113,9 +122,9 @@ const HouseProfile = () => {
       <Snackbar open={!!homeError}>
         <Alert severity="error">{"Error retrieving home data."}</Alert>
       </Snackbar>
-      <Snackbar open={isAssignmentError}>
+      {/* <Snackbar open={isAssignmentError}>
         <Alert severity="error">{"Error retrieving assignment data."}</Alert>
-      </Snackbar>
+      </Snackbar> */}
     </Container>
   );
 };

--- a/frontend/front/src/pages/Surveyor/houseProfile/HouseProfile.js
+++ b/frontend/front/src/pages/Surveyor/houseProfile/HouseProfile.js
@@ -10,10 +10,13 @@ import { HeatPumpSlide } from "../../../components/HeatPumpSlide";
 import { HeatPumpFade } from "../../../components/HeatPumpFade";
 import {
   useGetHomeQuery,
-  useCreateSurveyVisitMutation,
+  useCreateSurveyVisitMutation
 } from "../../../api/apiSlice";
 import { SubmissionSuccess } from "../Components/SubmissionSuccess";
-import { SurveyorSurvey } from "../Components/SurveyorSurvey";
+import {
+  SURVEYOR_SURVEY_ID,
+  SurveyorSurvey,
+} from "../Components/SurveyorSurvey";
 import Loader from "../../../components/Loader";
 
 const STEP_LOADING = "PHASE_LOADING";
@@ -41,13 +44,26 @@ const HouseProfile = () => {
 
   const submitSurvey = useCallback(
     async (responses, surveyId) => {
-      return await addSurveyVisit({
-        responses,
-        homeId,
-        surveyId,
-        // TODO: probably remove this and handle on the back end
-        date: new Date().toISOString(),
+      const surveyAnswers = {};
+      Object.entries(responses).forEach(([key, value]) => {
+        surveyAnswers[key] = {
+          survey_question_id: key,
+          answer: value,
+        };
       });
+
+      const surveyVisit = await addSurveyVisit({
+        survey_visit: {
+          home_id: homeId,
+          surveyor_id: "1",
+          survey_response_attributes: {
+            survey_id: surveyId,
+            completed: true,
+            survey_answers_attributes: surveyAnswers,
+          },
+        },
+      });
+      return surveyVisit;
     },
     [addSurveyVisit, homeId]
   );
@@ -81,7 +97,7 @@ const HouseProfile = () => {
       </HeatPumpFade>
       <HeatPumpSlide show={step === STEP_THANKS}>
         <SubmissionSuccess
-          surveyId={surveyVisitData?.surveyId}
+          surveyId={SURVEYOR_SURVEY_ID}
           submissionId={surveyVisitData?.id}
         />
       </HeatPumpSlide>

--- a/frontend/front/src/pages/Surveyor/houseProfile/HouseProfile.js
+++ b/frontend/front/src/pages/Surveyor/houseProfile/HouseProfile.js
@@ -11,6 +11,7 @@ import { HeatPumpFade } from "../../../components/HeatPumpFade";
 import {
   useGetHomeQuery,
   useCreateSurveyVisitMutation,
+  useGetAssignmentQuery,
 } from "../../../api/apiSlice";
 import { SubmissionSuccess } from "../Components/SubmissionSuccess";
 import {
@@ -31,6 +32,13 @@ const HouseProfile = () => {
     error: homesError,
     isLoading: isHomesLoading,
   } = useGetHomeQuery(homeId);
+  const assignmentId = homeData?.assignment_id;
+
+  const {
+    data: assignmentData,
+    isError: isAssignmentError,
+    isLoading: isAssignmentLoading,
+  } = useGetAssignmentQuery(assignmentId);
 
   const [
     addSurveyVisit,


### PR DESCRIPTION
Closes #334. 

Here's what's working and what has changed:
- [x] Can submit a survey via `surveyor/house/{homeId}`
- [x] Can _almost_ submit a survey via `public/survey` - see below
- [x] `createSurveyVisit()` in `apiSlice` accepts a recaptcha token and attaches it as a header
- [x] `SurveyPage` gets a recaptcha token using the `create_survey` action
- [x] Error loading `SurveyComponent` is fixed (the `Loader` in `SurveyComponentWrapper` is now inside a div that can receive a ref)

Here's what needs to be ironed out:
- [ ] No access to who is conducting a survey, so `surveyor_id` is hard-coded in on submission of `survey_visit` in surveyor view
- [ ] Cannot submit a public survey because backend requires a real `surveyor_id` (cannot be null)
- [ ] Is the data being stored properly? `survey_visits` and child `survey_responses` submitted via these pages don't display all attributes when queried:
  - `survey_visits` don't return a `home_id` despite including one on submission
  - `survey_responses` don't return a `completed` attribute despite including one on submission
  - Neither `survey_responses` nor `survey_visits` return with a foreign key linking to each other - this would prevent us from being able to link a survey response and its answers to a survey visit, which I think is a necessary function?