### PR TITLE
bug-fix: Fixed the Select dropdown components from cutting off survey…

### DIFF
--- a/frontend/front/src/components/SurveyComponent/HeatPumpDropdown.js
+++ b/frontend/front/src/components/SurveyComponent/HeatPumpDropdown.js
@@ -6,7 +6,13 @@ import {
   MenuItem,
   InputLabel,
 } from "@mui/material";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 /**
  * A radio group to be used with react-hook-form
@@ -21,20 +27,18 @@ export const HeatPumpDropdown = ({
 }) => {
   const { field: groupField, formState } = useController({ name, control });
 
-  const labelFormRef = useRef(null)
-  const [_, setResizeTrigger] = useState(0)
+  const labelFormRef = useRef(null);
+  const [_, setResizeTrigger] = useState(0);
 
   useEffect(() => {
-    const refresh = () => setResizeTrigger(prev => prev+1)
-    
-    refresh()
+    const refresh = () => setResizeTrigger((prev) => prev + 1);
 
-    window.addEventListener('resize', refresh)
-      
-    return () => window.removeEventListener('resize', refresh)
+    refresh();
 
-  })
-  
+    window.addEventListener("resize", refresh);
+
+    return () => window.removeEventListener("resize", refresh);
+  });
 
   const otherFieldName = `${name}/other`;
   const showOtherInput = useMemo(
@@ -52,14 +56,21 @@ export const HeatPumpDropdown = ({
     (field) => {
       return (
         <FormControl fullWidth error={!!mainFieldError}>
-          <InputLabel id={`${name}-dropdown-label`} sx={{whiteSpace: "normal"}}>
-            <div ref={labelFormRef} style={{paddingRight: '20px'}}>
-               {label}
+          <InputLabel
+            id={`${name}-dropdown-label`}
+            sx={{ whiteSpace: "normal" }}
+          >
+            <div ref={labelFormRef} style={{ paddingRight: "20px" }}>
+              {label}
             </div>
           </InputLabel>
           <Select
             label={label}
-            sx={{height: labelFormRef.current?.scrollHeight ? `${labelFormRef.current?.scrollHeight + 30}px` : null}}
+            sx={{
+              height: labelFormRef.current?.scrollHeight
+                ? `${labelFormRef.current?.scrollHeight + 30}px`
+                : null,
+            }}
             name={`${name}-dropdown`}
             aria-labelledby={`${name}-dropdown-label`}
             variant="filled"

--- a/frontend/front/src/components/SurveyComponent/HeatPumpDropdown.js
+++ b/frontend/front/src/components/SurveyComponent/HeatPumpDropdown.js
@@ -6,7 +6,7 @@ import {
   MenuItem,
   InputLabel,
 } from "@mui/material";
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /**
  * A radio group to be used with react-hook-form
@@ -20,6 +20,21 @@ export const HeatPumpDropdown = ({
   required,
 }) => {
   const { field: groupField, formState } = useController({ name, control });
+
+  const labelFormRef = useRef(null)
+  const [_, setResizeTrigger] = useState(0)
+
+  useEffect(() => {
+    const refresh = () => setResizeTrigger(prev => prev+1)
+    
+    refresh()
+
+    window.addEventListener('resize', refresh)
+      
+    return () => window.removeEventListener('resize', refresh)
+
+  })
+  
 
   const otherFieldName = `${name}/other`;
   const showOtherInput = useMemo(
@@ -37,9 +52,14 @@ export const HeatPumpDropdown = ({
     (field) => {
       return (
         <FormControl fullWidth error={!!mainFieldError}>
-          <InputLabel id={`${name}-dropdown-label`}>{label}</InputLabel>
+          <InputLabel id={`${name}-dropdown-label`} sx={{whiteSpace: "normal"}}>
+            <div ref={labelFormRef} style={{paddingRight: '20px'}}>
+               {label}
+            </div>
+          </InputLabel>
           <Select
             label={label}
+            sx={{height: labelFormRef.current?.scrollHeight ? `${labelFormRef.current?.scrollHeight + 30}px` : null}}
             name={`${name}-dropdown`}
             aria-labelledby={`${name}-dropdown-label`}
             variant="filled"


### PR DESCRIPTION
Fixed the Select dropdown components from cutting off survey questions

   - Wrapped label text in a <div> element within <InputLabel> and obtained scroll height using the assigned reference. (useRef)
   - Dynamically adjusted <Select> height based on the calculated scroll height of the wrapping <div>.
   - Utilized the useEffect to refresh the comonent to get the accurate height from the <div>, since it would set height before Ref was ready.
   - Added an event listener to detect font size changes, to make the height change dynamic.
   - Applied padding on right to the label/div to prevent overlapping with the arrow icon.