### PR TITLE
#449: Filter out empty answers before submitting the survey

### DIFF
--- a/frontend/front/src/pages/Admin/home/SurveyVisitProfile.js
+++ b/frontend/front/src/pages/Admin/home/SurveyVisitProfile.js
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo } from "react";
 import {
   useDeleteSurveyVisitMutation,
   useGetHomeQuery,
+  useGetSurveyStructureQuery,
   useGetSurveyVisitQuery,
   useUpdateSurveyVisitMutation,
 } from "../../../api/apiSlice";
@@ -19,6 +20,7 @@ import { buildDataFromSurveyAnswers } from "../../../util/surveyUtils";
 const SurveyProfile = () => {
   const navigate = useNavigate();
   const { uid: surveyVisitId } = useParams();
+
   const { data: surveyVisit, error: surveyVisitError } =
     useGetSurveyVisitQuery(surveyVisitId);
 
@@ -26,6 +28,11 @@ const SurveyProfile = () => {
     surveyVisit?.home_id,
     { skip: !surveyVisit }
   );
+
+  const { data: { survey_questions: surveyQuestions } = {} } =
+    useGetSurveyStructureQuery(surveyVisit?.survey_response?.survey_id, {
+      skip: !surveyVisit,
+    });
 
   const title = useMemo(
     () =>
@@ -39,10 +46,11 @@ const SurveyProfile = () => {
     () =>
       surveyVisit?.survey_response
         ? buildDataFromSurveyAnswers(
-            surveyVisit?.survey_response?.survey_answers
+            surveyVisit?.survey_response?.survey_answers,
+            surveyQuestions?.length
           )
         : [],
-    [surveyVisit]
+    [surveyVisit, surveyQuestions]
   );
 
   const [

--- a/frontend/front/src/util/surveyUtils.js
+++ b/frontend/front/src/util/surveyUtils.js
@@ -9,23 +9,33 @@ export const buildDefaultDataFromSurveyStructure = (surveyStructure) =>
     }),
     {}
   );
-export const buildDataFromSurveyAnswers = (surveyAnswers) =>
-  surveyAnswers.reduce(
-    (prev, curr) => ({
-      ...prev,
-      [curr.survey_question_id]: curr.answer,
-    }),
-    {}
-  );
+export const buildDataFromSurveyAnswers = (
+  surveyAnswers = [],
+  numberOfQuestions = 0
+) => {
+  const data = {};
+
+  for (let i = 1; i <= numberOfQuestions; i++) {
+    data[i] = "";
+  }
+
+  surveyAnswers.forEach((curr) => {
+    data[curr.survey_question_id] = curr.answer;
+  });
+
+  return data;
+};
 
 export const buildSurveyVisitData = (answers, homeId, surveyId, surveyorId) => {
   // build answers object
   const answersObject = {};
   Object.entries(answers).forEach(([key, value]) => {
-    answersObject[key] = {
-      survey_question_id: key,
-      answer: value,
-    };
+    if (answers[key]) {
+      answersObject[key] = {
+        survey_question_id: key,
+        answer: value,
+      };
+    }
   });
 
   return {


### PR DESCRIPTION
1. The buildSurveyVisitData function now includes an 'if (answers[key])' statement. So the survey data builds only for questions that have received a response. For example, {1: ‘’, 2: ‘yes’, 3: ‘’} becomes { 2: { survey_question_id: 2, answer: ‘yes'}}.

Note: This created an issue that when the survey only received responses for question 2, and the rest of the survey answers were undefined. And mui wornings went crazy in a loop.

2. The buildDataFromSurveyAnswers function then was modified to handle the missing data that came back. A numberOfQuestions parameter was added to it. For example, if the survey received only answer 2, 1, 3,.... was constructed as {1: ‘’, 2: ‘yes’, 3: ‘’.....}

3. I needed to get the number of survey quetions, so in SurveyVisitProfile.js, I integrated the useGetSurveyStructureQuery to dynamically retrieve the number of survey questions. I didn't want to hardcoding this value.