### PR TITLE
Add back survey_visit_ids to homes and assignments endpoints

### DIFF
--- a/backend/app/views/assignments/_assignment.json.jbuilder
+++ b/backend/app/views/assignments/_assignment.json.jbuilder
@@ -10,9 +10,6 @@ end
   h[:visit_order]
 end
 
-json.homes @sorted_homes do |home|
-  json.extract! home, :id, :street_number, :street_name, :unit_number, :city, :state, :zip_code,
-                :building_type, :visit_order, :latitude, :longitude
-  json.visited home.visited?
-  json.completed home.completed?
+json.homes do
+  json.array! @sorted_homes, partial: 'homes/home', as: :home
 end

--- a/backend/app/views/homes/_home.json.jbuilder
+++ b/backend/app/views/homes/_home.json.jbuilder
@@ -4,4 +4,5 @@ json.extract! home, :id, :street_number, :street_name, :unit_number, :city, :sta
               :status, :user_added, :assignment_id, :visit_order, :latitude, :longitude
 json.visited home.visited?
 json.completed home.completed?
+json.survey_visit_ids home.survey_visit_ids
 json.url home_url(home, format: :json)


### PR DESCRIPTION
This resolves #487 , undoing a change from ec340dc0421a829d0dab1c79b8bd898e54683324 – which I think was [accidental](https://github.com/codeforboston/urban-league-heat-pump-accelerator/commit/ec340dc0421a829d0dab1c79b8bd898e54683324#diff-00f0d7855d01d32e2d15e16f6067c6f7401f718f6c775c9d732ee26ca25e9aacL4).

I've checked the output, and it seems to be including the array as expected, although in my test instance I don't have any survey_visits to include (so only get an empty array).

I now get:
```bash
(487-add-back-survey_visit_ids) $ curl -s localhost:3000/homes.json | head -c 400
[{"id":2,"street_number":"8","street_name":"WARREN PL","unit_number":null,"city":"ROXBURY","state":"MA","zip_code":"02119","building_type":"TWO-FAM DWELLING","status":"unrecognized","user_added":false,"assignment_id":2,"visit_order":2,"latitude":"42.3281053","longitude":"-71.08229235","visited":false,"completed":false,"survey_visit_ids":[],"url":"http://localhost:3000/homes/2.json"},{"id":3,"stree
(487-add-back-survey_visit_ids) $ curl -s localhost:3000/assignments.json | head -c 600
[{"id":1,"group":"A1","region_code":1,"geocode":"42.35493388720329, -71.07422031985483","surveyor_ids":[1],"homes":[]},{"id":2,"group":"A2","region_code":1,"geocode":"42.364389744746916, -71.05387467871688","surveyor_ids":[1],"homes":[{"id":1,"street_number":"6","street_name":"WARREN PL","unit_number":null,"city":"ROXBURY","state":"MA","zip_code":"02119","building_type":"THREE-FAM DWELLING","status":"unrecognized","user_added":false,"assignment_id":2,"visit_order":1,"latitude":"42.32811808","longitude":"-71.08244678","visited":false,"completed":false,"survey_visit_ids":[],"url":"http://localho
```