### PR TITLE
Frontend issue 540 smart screen column

### DIFF
--- a/frontend/front/src/pages/Admin/AdminContainer.js
+++ b/frontend/front/src/pages/Admin/AdminContainer.js
@@ -32,7 +32,7 @@ const AdminContainer = () => {
     <Box>
       <Box>
         <Nav />
-        <Tabs value={tabValue}>
+        <Tabs value={tabValue} variant="scrollable" allowScrollButtonsMobile>
           <Tab
             label="HOMES"
             value={routes.ADMIN_HOME}

--- a/frontend/front/src/pages/Admin/assignment/AssignTable.js
+++ b/frontend/front/src/pages/Admin/assignment/AssignTable.js
@@ -126,7 +126,8 @@ const AssignTable = () => {
     {
       field: "surveyorData",
       headerName: "Surveyor(s)",
-      flex: 1,
+      minWidth: 150,
+      flex: 2,
       renderCell: (params) => {
         return params.row.surveyorData ? (
           <Stack

--- a/frontend/front/src/pages/Admin/survey/SurveyTable.js
+++ b/frontend/front/src/pages/Admin/survey/SurveyTable.js
@@ -15,16 +15,37 @@ import { ADMIN_SURVEY, withAdminPrefix } from "../../../routing/routes";
 import { SurveyError } from "./SurveyError";
 
 const COLUMNS = [
-  { field: "id", headerName: "Survey ID", flex: 1 },
+  {
+    field: "id",
+    headerName: "Survey ID",
+    minWidth: 50,
+    flex: 0.7,
+  },
   {
     field: "home_address",
     headerName: "Address",
-    flex: 1,
+    minWidth: 150,
+    flex: 1.5,
   },
-  { field: "city", headerName: "City", flex: 1 },
-  { field: "surveyor", headerName: "Surveyor", flex: 1 },
-  { field: "created", headerName: "Created", flex: 1 },
-  { field: "lastUpdated", headerName: "Last Updated", flex: 1 },
+  { field: "city", headerName: "City", minWidth: 100, flex: 1.2 },
+  {
+    field: "surveyor",
+    headerName: "Surveyor",
+    minWidth: 100,
+    flex: 1.2,
+  },
+  {
+    field: "created",
+    headerName: "Created",
+    minWidth: 155,
+    flex: 1.5,
+  },
+  {
+    field: "lastUpdated",
+    headerName: "Last Updated",
+    minWidth: 155,
+    flex: 1.5,
+  },
 ];
 
 const SurveyTable = () => {

--- a/frontend/front/src/pages/Admin/user/UserTable.js
+++ b/frontend/front/src/pages/Admin/user/UserTable.js
@@ -11,13 +11,13 @@ import {
 import { ADMIN_USER, withAdminPrefix } from "../../../routing/routes";
 
 const columns = [
-  { field: "id", headerName: "User ID", flex: 0.7 },
-  { field: "firstname", headerName: "First Name", flex: 1 },
-  { field: "lastname", headerName: "Last Name", flex: 1 },
-  { field: "email", headerName: "Email", flex: 2 },
-  { field: "phone", headerName: "Phone", flex: 1 },
-  { field: "role", headerName: "Role", flex: 1 },
-  { field: "status", headerName: "Status", flex: 1 },
+  { field: "id", headerName: "User ID", minWidth: 50, flex: 0.7 },
+  { field: "firstname", headerName: "First Name", minWidth: 100, flex: 1 },
+  { field: "lastname", headerName: "Last Name", minWidth: 100, flex: 1 },
+  { field: "email", headerName: "Email", minWidth: 200, flex: 1.5 },
+  { field: "phone", headerName: "Phone", minWidth: 120, flex: 1.2 },
+  { field: "role", headerName: "Role", minWidth: 100, flex: 1 },
+  { field: "status", headerName: "Status", minWidth: 90, flex: 0.8 },
 ];
 
 const UserTable = () => {


### PR DESCRIPTION
- Add horizontal scrolling to users, surveys, assignments tab to prevent small column size on small screen size.
- Add horizontal scrolling to admin tab navigation when content is too wide for small screen screen size.

Closes #540 