### PR TITLE
Fix cve-2024-41123: DoS vulnerabilities in REXML

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -18,6 +18,7 @@ gem 'pundit'
 gem 'rack', '~> 2.0'
 gem 'rack-cors', '~> 2.0'
 gem 'rails', '>= 7.0'
+gem 'rexml', '>= 3.3.3'
 gem 'sprockets-rails'
 gem 'sucker_punch', '~> 3.0'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -237,7 +237,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.3.2)
+    rexml (3.3.4)
       strscan
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
@@ -334,6 +334,7 @@ DEPENDENCIES
   rack (~> 2.0)
   rack-cors (~> 2.0)
   rails (>= 7.0)
+  rexml (>= 3.3.3)
   rspec-rails (~> 6.0.0)
   rubocop
   rubocop-rails


### PR DESCRIPTION
It looks like Bundler audit caught the following issue:

```
Name: rexml
Version: 3.3.2
CVE: CVE-202[4](https://github.com/codeforboston/urban-league-heat-pump-accelerator/actions/runs/10250868096/job/28357566019?pr=589#step:6:4)-41123
GHSA: GHSA-r55c-59qm-vjw6
Criticality: Medium
URL: https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123
Title: DoS vulnerabilities in REXML
Solution: upgrade to '>= 3.3.3'
```

https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123/