### PR TITLE
Change UserProfile.js query from user_id to id

### DIFF
--- a/frontend/front/src/hooks/breadcrumbHooks.js
+++ b/frontend/front/src/hooks/breadcrumbHooks.js
@@ -30,7 +30,7 @@ export const useGoToBreadcrumb = () => {
         }`;
         break;
       case "user":
-        url = `/admin/user/userProfile/${data?.user_id}`;
+        url = `/admin/user/userProfile/${data?.id}`;
         description = `${data?.firstname} ${data?.lastname}`;
         break;
       case "surveyVisit":


### PR DESCRIPTION
- Fixes an issue in #598 ```Couldn't find Surveyor with 'id'``` error because of mismatched id and user_id