### PR TITLE
Allow latitude and longitude to be stored on survey visits

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -26,6 +26,7 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'
+  gem 'pry'
   gem 'rspec-rails', '~> 6.0.0'
 end
 

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     bundler-audit (0.9.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
+    coderay (1.1.3)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -154,6 +155,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.24.1)
     msgpack (1.7.2)
@@ -181,6 +183,9 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     psych (5.1.2)
       stringio
     puma (5.6.8)
@@ -329,6 +334,7 @@ DEPENDENCIES
   jbuilder
   newrelic_rpm
   pg (~> 1.1)
+  pry
   puma (~> 5.0)
   pundit
   rack (~> 2.0)

--- a/backend/app/controllers/survey_visits_controller.rb
+++ b/backend/app/controllers/survey_visits_controller.rb
@@ -71,7 +71,7 @@ class SurveyVisitsController < ApplicationController
   # Only allow a list of trusted parameters through.
   def survey_visit_params
     params.require(:survey_visit)
-          .permit(:surveyor_id, :home_id,
+          .permit(:surveyor_id, :home_id, :latitude, :longitude,
                   survey_response_attributes: [:survey_id,
                                                { survey_answers_attributes: %i[survey_question_id answer] }])
   end

--- a/backend/db/migrate/20240816145140_add_latitude_longitude_to_survey_visits.rb
+++ b/backend/db/migrate/20240816145140_add_latitude_longitude_to_survey_visits.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddLatitudeLongitudeToSurveyVisits < ActiveRecord::Migration[7.1]
+  def change
+    change_table :survey_visits, bulk: true do |t|
+      t.string :latitude
+      t.string :longitude
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_31_015953) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_16_145140) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -114,6 +114,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_31_015953) do
     t.datetime "updated_at", null: false
     t.bigint "home_id"
     t.bigint "surveyor_id"
+    t.string "latitude"
+    t.string "longitude"
     t.index ["home_id"], name: "index_survey_visits_on_home_id"
     t.index ["surveyor_id"], name: "index_survey_visits_on_surveyor_id"
   end

--- a/backend/spec/requests/survey_visits_spec.rb
+++ b/backend/spec/requests/survey_visits_spec.rb
@@ -20,8 +20,7 @@ RSpec.describe '/survey_visits', type: :request do
   # SurveyVisit. As you add validations to SurveyVisit, be sure to
   # adjust the attributes here as well.
   let(:survey) { create(:survey) }
-  let(:survey_visit) { create(:survey_visit) }
-  let(:home) { survey_visit.home }
+  let(:home) { create(:home) }
   let(:localized_survey_question) { create(:localized_survey_question) }
   let(:survey_question) { localized_survey_question.survey_question }
   let(:surveyor) { create(:surveyor) }
@@ -29,6 +28,8 @@ RSpec.describe '/survey_visits', type: :request do
     {
       surveyor_id: surveyor.id,
       home_id: home.id,
+      latitude: '41.0895249',
+      longitude: '-71.9419063',
       survey_response_attributes: {
         survey_id: survey.id,
         survey_answers_attributes: [
@@ -39,10 +40,6 @@ RSpec.describe '/survey_visits', type: :request do
         ]
       }
     }
-    # params.require(:survey_visit)
-    #       .permit(:surveyor_id, :home_id,
-    #               survey_response_attributes: [:survey_id, :completed,
-    #                                            { survey_answers_attributes: %i[survey_question_id answer] }])
   end
 
   let(:invalid_attributes) do
@@ -77,10 +74,20 @@ RSpec.describe '/survey_visits', type: :request do
   describe 'POST /create' do
     context 'with valid parameters' do
       it 'creates a new SurveyVisit' do
-        pending 'fix valid attributes in branch fix-cors-for-staging'
         expect do
           post survey_visits_url, params: { survey_visit: valid_attributes }, as: :json
         end.to change(SurveyVisit, :count).by(1)
+
+        survey_visit = SurveyVisit.last
+        expect(survey_visit.home_id).to eq(home.id)
+        expect(survey_visit.surveyor_id).to eq(surveyor.id)
+        expect(survey_visit.latitude).to eq('41.0895249')
+        expect(survey_visit.longitude).to eq('-71.9419063')
+
+        survey_response = survey_visit.survey_response
+        expect(survey_response).to be_present
+        expect(survey_response.survey_id).to eq(survey.id)
+        expect(survey_response.survey_answers.count).to eq(1)
       end
 
       it 'redirects to the created survey_visit' do


### PR DESCRIPTION
Link to issue: https://github.com/codeforboston/urban-league-heat-pump-accelerator/issues/553

This PR will allow the front end to pass the latitude & longitude of the surveyor when they submit the survey visit.

Also heads up - I added the 'pry' gem to the development section of the Gemfile since I use it frequently! Thanks