### PR TITLE
Add role to surveyors index

### DIFF
--- a/backend/app/controllers/surveyors_controller.rb
+++ b/backend/app/controllers/surveyors_controller.rb
@@ -6,7 +6,7 @@ class SurveyorsController < ApplicationController
 
   # GET /surveyors or /surveyors.json
   def index
-    @surveyors = policy_scope(Surveyor).where(search_params)
+    @surveyors = policy_scope(Surveyor).where(search_params).includes(:user)
   end
 
   # GET /surveyors/1 or /surveyors/1.json

--- a/backend/app/views/surveyors/_surveyor.json.jbuilder
+++ b/backend/app/views/surveyors/_surveyor.json.jbuilder
@@ -2,4 +2,6 @@
 
 json.extract! surveyor, :id, :user_id, :assignment_ids, :firstname, :lastname, :email, :phone, :street_address, :city,
               :state, :zipcode, :geocode, :status
+
+json.role surveyor.user.role
 json.url surveyor_url(surveyor, format: :json)

--- a/backend/spec/requests/surveyors_spec.rb
+++ b/backend/spec/requests/surveyors_spec.rb
@@ -52,19 +52,45 @@ RSpec.describe '/surveyors', type: :request do
   end
 
   describe 'GET /index' do
+    before do
+      @surveyor = Surveyor.create! valid_attributes
+      sign_in user
+    end
+
     it 'renders a successful response' do
-      Surveyor.create! valid_attributes
       get surveyors_url, as: :json
       expect(response).to be_successful
+
+      surveyors_json = JSON.parse(response.body)
+      expect(surveyors_json[0]['id']).to eq(@surveyor.id)
     end
   end
 
   describe 'GET /show' do
-    it 'renders a successful response' do
+    before do
+      @surveyor = Surveyor.create! valid_attributes
       sign_in user
-      surveyor = Surveyor.create! valid_attributes
-      get surveyor_url(surveyor), as: :json
+    end
+
+    it 'renders a successful response' do
+      get surveyor_url(@surveyor), as: :json
       expect(response).to be_successful
+
+      surveyor_json = JSON.parse(response.body)
+      expect(surveyor_json['id']).to eq(@surveyor.id)
+      expect(surveyor_json['user_id']).to eq(user.id)
+      expect(surveyor_json['assignment_ids']).to eq([])
+      expect(surveyor_json['firstname']).to eq('John')
+      expect(surveyor_json['lastname']).to eq('Smith')
+      expect(surveyor_json['email']).to eq('johnsmith@example.com')
+      expect(surveyor_json['phone']).to eq('1234567890')
+      expect(surveyor_json['street_address']).to eq('123 First Street')
+      expect(surveyor_json['city']).to eq('Cambridge')
+      expect(surveyor_json['state']).to eq('MA')
+      expect(surveyor_json['zipcode']).to eq('01234')
+      expect(surveyor_json['status']).to eq('active')
+      expect(surveyor_json['role']).to eq('surveyor')
+      expect(surveyor_json['url']).to eq("http://www.example.com/surveyors/#{@surveyor.id}.json")
     end
   end
 


### PR DESCRIPTION
The Users page has a column for "role" which is empty because we're not returning the field on the `GET /surveyors` index.  When we return the field on the API the front end does render the value - see screenshot from local environment after code change:

<img width="1069" alt="Screenshot 2024-08-16 at 12 53 57 PM" src="https://github.com/user-attachments/assets/acd90a12-e2ad-4273-924a-658f0ecb4269">


