### PR TITLE
Remove home queries

### DIFF
--- a/backend/app/views/survey_visits/_survey_visit.json.jbuilder
+++ b/backend/app/views/survey_visits/_survey_visit.json.jbuilder
@@ -2,6 +2,22 @@
 
 json.extract! survey_visit, :id, :surveyor_id, :home_id, :created_at, :updated_at
 json.url survey_visit_url(survey_visit, format: :json)
+if survey_visit.surveyor_id.present?
+  json.surveyor do
+    json.id survey_visit.surveyor.id
+    json.firstname survey_visit.surveyor.firstname
+    json.lastname survey_visit.surveyor.lastname
+  end
+end
+json.home do
+  json.id survey_visit.home.id
+  json.street_number survey_visit.home.street_number
+  json.street_name survey_visit.home.street_name
+  json.unit_number survey_visit.home.unit_number
+  json.city survey_visit.home.city
+  json.state survey_visit.home.state
+  json.zip_code survey_visit.home.zip_code
+end
 if survey_visit.survey_response.present?
   json.survey_response do
     json.id survey_visit.survey_response.id

--- a/frontend/front/src/pages/Admin/home/SurveyVisitProfile.js
+++ b/frontend/front/src/pages/Admin/home/SurveyVisitProfile.js
@@ -1,7 +1,6 @@
 import { Container, Typography } from "@mui/material";
 import React, { useMemo } from "react";
 import {
-  useGetHomeQuery,
   useGetSurveyStructureQuery,
   useGetSurveyVisitQuery,
 } from "../../../api/apiSlice";
@@ -19,28 +18,22 @@ const SurveyProfile = () => {
   const { data: surveyVisit, error: surveyVisitError } =
     useGetSurveyVisitQuery(surveyVisitId);
 
-  const { data: houseData, error: houseError } = useGetHomeQuery(
-    surveyVisit?.home_id,
-    { skip: !surveyVisit }
-  );
-
   const { data: { survey_questions: surveyQuestions } = {} } =
     useGetSurveyStructureQuery(surveyVisit?.survey_response?.survey_id, {
       skip: !surveyVisit,
     });
 
   const title = useMemo(
-    () =>
-      surveyVisit && houseData ? `${houseToString(houseData)}` : "Loading...",
-    [houseData, surveyVisit]
+    () => (surveyVisit ? `${houseToString(surveyVisit.home)}` : "Loading..."),
+    [surveyVisit]
   );
 
   const completedTime = useMemo(
     () =>
-      surveyVisit && houseData
+      surveyVisit
         ? `Completed at: ${formatISODate(surveyVisit.created_at)}`
         : "Loading...",
-    [houseData, surveyVisit]
+    [surveyVisit]
   );
 
   const surveyAnswers = useMemo(
@@ -62,14 +55,14 @@ const SurveyProfile = () => {
       <Typography variant="subtitle1" mt={2}>
         {completedTime}
       </Typography>
-      {surveyVisit && houseData ? (
+      {surveyVisit ? (
         <AdminSurvey
           defaultData={surveyAnswers}
-          activeHome={houseData}
+          activeHome={surveyVisit.home}
           surveyId={surveyVisit.survey_response.survey_id}
           readOnly
         />
-      ) : surveyVisitError || houseError ? (
+      ) : surveyVisitError ? (
         <SurveyError />
       ) : (
         <Loader />


### PR DESCRIPTION
- Add surveyor and home to survey_visit json response as SurveyVisitProfile and SurveyTable need to make additional api calls to get render data.
- Remove queries and returned values on SurveyVisitProfile and SurveyTable
- Remove updatedAt column as survey cannot be edited anymore.
- Add "Public Submission" to surveyor column when a survey is submitted via Public Survey page (surveyor_id is null).