### PR TITLE
Better Error for Not found Language Code

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -1,3 +1,5 @@
 inherit_from: .rubocop_todo.yml
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never
 
 require: rubocop-rails

--- a/backend/app/controllers/surveys_controller.rb
+++ b/backend/app/controllers/surveys_controller.rb
@@ -17,9 +17,10 @@ class SurveysController < ApplicationController
     # If first question of survey doesn't have this localization, then throw exception
     # (No need to check all questions for this localization)
     return unless @survey.survey_questions.first.localized_survey_questions.find_by(language_code: @language_code).nil?
-
-    raise StandardError,
-          "Survey question #{@survey.id} does not have localization '#{@language_code}'"
+    
+    respond_to do |format|
+      format.json { render :show, status: :404, error: "{ \"status\": \"Survey question #{@survey.id} does not have localization #{@language_code}\" }" }
+    end
   end
 
   # GET /surveys/new

--- a/backend/app/controllers/surveys_controller.rb
+++ b/backend/app/controllers/surveys_controller.rb
@@ -17,9 +17,11 @@ class SurveysController < ApplicationController
     # If first question of survey doesn't have this localization, then throw exception
     # (No need to check all questions for this localization)
     return unless @survey.survey_questions.first.localized_survey_questions.find_by(language_code: @language_code).nil?
-    
+
     respond_to do |format|
-      format.json { render :show, status: :404, error: "{ \"status\": \"Survey #{@survey.id} does not have localization #{@language_code}\" }" }
+      format.json do
+        render json: "{ \"status\": \"Survey #{@survey.id} does not have localization #{@language_code}\" }", status: :not_found
+      end
     end
   end
 

--- a/backend/app/controllers/surveys_controller.rb
+++ b/backend/app/controllers/surveys_controller.rb
@@ -20,7 +20,8 @@ class SurveysController < ApplicationController
 
     respond_to do |format|
       format.json do
-        render json: "{ \"status\": \"Survey #{@survey.id} does not have localization #{@language_code}\" }", status: :not_found
+        render json: "{ \"status\": \"Survey #{@survey.id} does not have localization #{@language_code}\" }",
+               status: :not_found
       end
     end
   end

--- a/backend/app/controllers/surveys_controller.rb
+++ b/backend/app/controllers/surveys_controller.rb
@@ -19,7 +19,7 @@ class SurveysController < ApplicationController
     return unless @survey.survey_questions.first.localized_survey_questions.find_by(language_code: @language_code).nil?
     
     respond_to do |format|
-      format.json { render :show, status: :404, error: "{ \"status\": \"Survey question #{@survey.id} does not have localization #{@language_code}\" }" }
+      format.json { render :show, status: :404, error: "{ \"status\": \"Survey #{@survey.id} does not have localization #{@language_code}\" }" }
     end
   end
 

--- a/backend/app/models/survey_question.rb
+++ b/backend/app/models/survey_question.rb
@@ -9,7 +9,7 @@ class SurveyQuestion < ApplicationRecord
   validates :display_order, uniqueness: { scope: :survey_id }
 
   def text(language_code)
-    lsq = localized_survey_questions.find_by(language_code:)
+    lsq = localized_survey_questions.find_by(language_code: language_code)
 
     raise StandardError, "Survey question #{id} does not have localization '#{language_code}'" if lsq.nil?
 
@@ -17,7 +17,7 @@ class SurveyQuestion < ApplicationRecord
   end
 
   def response_options(language_code)
-    lsq = localized_survey_questions.find_by(language_code:)
+    lsq = localized_survey_questions.find_by(language_code: language_code)
 
     raise StandardError, "Survey question #{id} does not have localization '#{language_code}'" if lsq.nil?
 

--- a/backend/app/policies/surveyor_policy.rb
+++ b/backend/app/policies/surveyor_policy.rb
@@ -41,7 +41,7 @@ class SurveyorPolicy < ApplicationPolicy
       if user&.admin?
         scope.all
       else
-        scope.where(user:)
+        scope.where(user: user)
       end
     end
 

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -40,6 +40,6 @@ module UrbanLeagueHeatPumpAccelerator
     config.active_job.queue_adapter = :sucker_punch
 
     config.autoload_paths += %W[#{config.root}/lib]
-    config.action_dispatch.rescue_responses["Pundit::NotAuthorizedError"] = :forbidden
+    config.action_dispatch.rescue_responses['Pundit::NotAuthorizedError'] = :forbidden
   end
 end

--- a/backend/spec/requests/assignments_spec.rb
+++ b/backend/spec/requests/assignments_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe '/assignments', type: :request do
   let!(:user) { FactoryBot.create(:user) }
   let!(:home) { FactoryBot.create(:home) }
   let!(:surveyor) do
-    FactoryBot.create(:surveyor, user:) do |surveyor|
+    FactoryBot.create(:surveyor, user: user) do |surveyor|
       FactoryBot.create_list(:assignment, 1, surveyors: [surveyor])
       home.update(assignment: surveyor.assignments[0], visit_order: 1)
     end

--- a/backend/spec/requests/surveys_spec.rb
+++ b/backend/spec/requests/surveys_spec.rb
@@ -35,10 +35,19 @@ RSpec.describe '/surveys', type: :request do
   end
 
   describe 'GET /show' do
+    let(:survey) do
+      localized_survey_question = create(:localized_survey_question, language_code: 'en-US')
+      localized_survey_question.survey_question.survey
+    end
+
     it 'renders a successful response' do
-      survey = Survey.create! valid_attributes
-      get survey_url(survey), as: :json
+      get survey_url(survey, langPref: 'en-US'), as: :json
       expect(response).to be_successful
+    end
+
+    it 'renders a 404 not found if langPref not found' do
+      get survey_url(survey, langPref: 'foo'), as: :json
+      expect(response).to have_http_status(:not_found)
     end
   end
 


### PR DESCRIPTION
* Instead of raising StandardError and returning a 500, we return a 404 with some helpfully descriptive JSON text.