### PR TITLE
Create langPref validator, send langPref param to backend

### DIFF
--- a/frontend/front/src/api/apiSlice.js
+++ b/frontend/front/src/api/apiSlice.js
@@ -2,6 +2,7 @@ import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 import { AUTHORIZATION_HEADER } from "../features/login/loginUtils";
 import { transformSurveyorKeys } from "../features/surveyor/surveyorUtils";
+import { validateLanguage } from "../util/surveyUtils";
 
 const baseUrl = process.env.REACT_APP_API_URL || "http://localhost:3000";
 
@@ -140,10 +141,14 @@ export const apiSlice = createApi({
       ],
     }),
     getSurveyStructure: builder.query({
-      query: (id) => ({
-        url: `/surveys/${id}`,
-        method: "GET",
-      }),
+      query: (id) => {
+        const validatedLangPref = validateLanguage();
+        return {
+          url: `/surveys/${id}`,
+          method: "GET",
+          params: { langPref: validatedLangPref },
+        };
+      },
       providesTags: (result, error, arg) => [{ type: "Survey", id: arg }],
     }),
     createSurvey: builder.mutation({

--- a/frontend/front/src/pages/Public/Components/LangPrefDropdown.js
+++ b/frontend/front/src/pages/Public/Components/LangPrefDropdown.js
@@ -17,10 +17,10 @@ const LangPrefDropdown = () => {
   const location = useLocation();
 
   const langMap = {
-    "en-us": `🇺🇸 ${t("public.global-labels.locales.english")}`,
-    "ht-cr": `🇭🇹 ${t("public.global-labels.locales.creole")}`,
-    "pt-br": `🇧🇷 ${t("public.global-labels.locales.portuguese")}`,
-    "es-us": `🇪🇸 ${t("public.global-labels.locales.spanish")}`,
+    "en-US": `🇺🇸 ${t("public.global-labels.locales.english")}`,
+    "ht-CR": `🇭🇹 ${t("public.global-labels.locales.creole")}`,
+    "pt-BR": `🇧🇷 ${t("public.global-labels.locales.portuguese")}`,
+    "es-US": `🇪🇸 ${t("public.global-labels.locales.spanish")}`,
   };
 
   useEffect(() => {
@@ -32,15 +32,15 @@ const LangPrefDropdown = () => {
     const isPublicRoute = location.pathname.includes("public");
 
     if (isPublicRoute) {
-      // Get language preference from localStorage or default to 'en-us'
-      queryLang = localStorage.getItem("langPref") || "en-us";
+      // Get language preference from localStorage or default to 'en-US'
+      queryLang = localStorage.getItem("langPref") || "en-US";
 
       if (!localStorage.getItem("langPref")) {
-        localStorage.setItem("langPref", "en-us");
+        localStorage.setItem("langPref", "en-US");
       }
 
       // Update or remove 'langPref' query param based on language
-      if (queryLang !== "en-us") {
+      if (queryLang !== "en-US") {
         params.set("langPref", queryLang);
       } else {
         params.delete("langPref");
@@ -85,7 +85,7 @@ const LangPrefDropdown = () => {
 
     // Update or remove 'langPref' query param based on route and language
     if (url.pathname.includes("public")) {
-      if (lang !== "en-us") {
+      if (lang !== "en-US") {
         url.searchParams.set("langPref", lang);
       } else {
         url.searchParams.delete("langPref");

--- a/frontend/front/src/pages/Public/Libs/i18n.js
+++ b/frontend/front/src/pages/Public/Libs/i18n.js
@@ -5,7 +5,7 @@ import ptTranslations from "../locales/pt-BR.json";
 import esTranslations from "../locales/es-419.json";
 import htTranslations from "../locales/ht.json";
 
-const userLangPref = localStorage.getItem("langPref") || "en-us";
+const userLangPref = localStorage.getItem("langPref") || "en-US";
 
 // configuration for i18next library
 i18next

--- a/frontend/front/src/util/surveyUtils.js
+++ b/frontend/front/src/util/surveyUtils.js
@@ -1,13 +1,13 @@
 // Current supported survey languages
-const supportedLanguages = ["en"];
+const supportedLanguages = ["en-US"];
 
 export const validateLanguage = () => {
   const langPref = localStorage.getItem("langPref");
   if (typeof langPref !== "string") {
-    return "en";
+    return "en-US";
   }
   const generalLang = langPref.split("-")[0];
-  return supportedLanguages.includes(generalLang) ? generalLang : "en";
+  return supportedLanguages.includes(generalLang) ? generalLang : "en-US";
 };
 
 export const buildSurveyCacheKey = (surveyId, homeId) =>

--- a/frontend/front/src/util/surveyUtils.js
+++ b/frontend/front/src/util/surveyUtils.js
@@ -1,3 +1,15 @@
+// Current supported survey languages
+const supportedLanguages = ["en"];
+
+export const validateLanguage = () => {
+  const langPref = localStorage.getItem("langPref");
+  if (typeof langPref !== "string") {
+    return "en";
+  }
+  const generalLang = langPref.split("-")[0];
+  return supportedLanguages.includes(generalLang) ? generalLang : "en";
+};
+
 export const buildSurveyCacheKey = (surveyId, homeId) =>
   `survey${surveyId}-home${homeId}`;
 


### PR DESCRIPTION
- Add a langPref validator with 'en-US' as fallback
- Change language codes to capitalized countries
- Call langPref validator before sending langPref param to backend

Fixes #615 
Fixes #616