### PR TITLE
Fix answers array public survey

### DIFF
--- a/frontend/front/src/pages/Public/Pages/SurveyPage.js
+++ b/frontend/front/src/pages/Public/Pages/SurveyPage.js
@@ -13,7 +13,10 @@ import {
 
 import { HeatPumpFade } from "../../../components/HeatPumpFade";
 import { HeatPumpSlide } from "../../../components/HeatPumpSlide";
-import { buildSurveyVisitData } from "../../../util/surveyUtils";
+import {
+  buildSurveyVisitData,
+  surveyAnswersToArray,
+} from "../../../util/surveyUtils";
 import { AddressValidatorComponent } from "../Components/AddressValidatorComponent";
 import { PublicSurvey } from "../Components/PublicSurvey";
 import { ThanksForSubmission } from "../Components/ThanksForSubmission";
@@ -77,8 +80,9 @@ export const SurveyPage = () => {
   const handleAddSurveyVisit = useCallback(
     async (answers, surveyId, homeId, _) => {
       const recaptcha = await getReCaptchaToken("create_survey");
+      const arrayAnswers = surveyAnswersToArray(answers);
       const surveyVisit = await addSurveyVisit({
-        surveyVisit: buildSurveyVisitData(answers, homeId, surveyId, null, {
+        surveyVisit: buildSurveyVisitData(arrayAnswers, homeId, surveyId, null, {
           latitude: null,
           longitude: null,
         }),

--- a/frontend/front/src/pages/Public/Pages/SurveyPage.js
+++ b/frontend/front/src/pages/Public/Pages/SurveyPage.js
@@ -82,10 +82,16 @@ export const SurveyPage = () => {
       const recaptcha = await getReCaptchaToken("create_survey");
       const arrayAnswers = surveyAnswersToArray(answers);
       const surveyVisit = await addSurveyVisit({
-        surveyVisit: buildSurveyVisitData(arrayAnswers, homeId, surveyId, null, {
-          latitude: null,
-          longitude: null,
-        }),
+        surveyVisit: buildSurveyVisitData(
+          arrayAnswers,
+          homeId,
+          surveyId,
+          null,
+          {
+            latitude: null,
+            longitude: null,
+          }
+        ),
         recaptcha,
       });
       if (isSurveyVisitSucess) {


### PR DESCRIPTION
I was testing the Export surveys button and saw that surveys submitted by a surveyor correctly had all the answers, but the answers to public surveys were all blank.

It looks like the recent change made here: https://github.com/codeforboston/urban-league-heat-pump-accelerator/commit/db15b38ca30d2a15a777712f51d1b0da5063378b needs to be extended for public survey answers