### PR TITLE
646 Remove old answer field

### DIFF
--- a/backend/app/controllers/survey_visits_controller.rb
+++ b/backend/app/controllers/survey_visits_controller.rb
@@ -74,7 +74,7 @@ class SurveyVisitsController < ApplicationController
           .permit(:surveyor_id, :home_id, :latitude, :longitude,
                   survey_response_attributes: [:survey_id,
                                                { survey_answers_attributes: [:survey_question_id,
-                                                                             :answer, { answers: [] }] }])
+                                                                             { answers: [] }] }])
   end
 
   def search_params

--- a/backend/app/views/survey_visits/_survey_visit.json.jbuilder
+++ b/backend/app/views/survey_visits/_survey_visit.json.jbuilder
@@ -25,7 +25,6 @@ if survey_visit.survey_response.present?
     json.survey_answers survey_visit.survey_response.survey_answers do |sa|
       json.id sa.id
       json.survey_question_id sa.survey_question_id
-      json.answer sa.answer
       json.answers sa.answers
     end
   end

--- a/backend/db/migrate/20250324174954_remove_answer_from_survey_answers.rb
+++ b/backend/db/migrate/20250324174954_remove_answer_from_survey_answers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveAnswerFromSurveyAnswers < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :survey_answers, :answer, :text
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_29_235813) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_24_174954) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -82,7 +82,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_29_235813) do
   end
 
   create_table "survey_answers", force: :cascade do |t|
-    t.text "answer"
     t.bigint "survey_response_id", null: false
     t.bigint "survey_question_id", null: false
     t.datetime "created_at", null: false

--- a/backend/spec/factories/survey_answers.rb
+++ b/backend/spec/factories/survey_answers.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :survey_answer do
-    answer { 'MyText' }
     survey_response
     survey_question
   end

--- a/backend/spec/models/csv_export_helper_spec.rb
+++ b/backend/spec/models/csv_export_helper_spec.rb
@@ -117,9 +117,7 @@ RSpec.describe CsvExportHelper, type: :model do
       assignment.update!(surveyors: [@surveyor])
 
       @survey_visit = create(:survey_visit, home: home, surveyor: @surveyor, latitude: '33.333', longitude: '44.444')
-      survey_response = create(:survey_response, survey: survey, survey_visit: @survey_visit)
-      create(:survey_answer, survey_question: survey_question, answer: 'Yes I would love a heat pump',
-                             survey_response: survey_response)
+      create(:survey_response, survey: survey, survey_visit: @survey_visit)
 
       actual = CsvExportHelper.survey_visit_hash(@survey_visit)
       expect(actual[:public_survey]).to eq('No')

--- a/backend/spec/requests/survey_visits_spec.rb
+++ b/backend/spec/requests/survey_visits_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe '/survey_visits', type: :request do
         survey_answers_attributes: [
           {
             survey_question_id: survey_question.id,
-            answer: 1,
             answers: %w[Foo Bar]
           }
         ]


### PR DESCRIPTION
https://github.com/codeforboston/urban-league-heat-pump-accelerator/issues/646

Frontend has switched to using `survey_answer.answers` so this PR removes the old `survey_answer.answer` field.