### PR TITLE
Add language code to survey responses

### DIFF
--- a/backend/app/controllers/survey_visits_controller.rb
+++ b/backend/app/controllers/survey_visits_controller.rb
@@ -74,7 +74,7 @@ class SurveyVisitsController < ApplicationController
   def survey_visit_params
     params.require(:survey_visit)
           .permit(:surveyor_id, :home_id, :latitude, :longitude,
-                  survey_response_attributes: [:survey_id,
+                  survey_response_attributes: [:survey_id, :language_code,
                                                { survey_answers_attributes: [:survey_question_id,
                                                                              { answers: [] }] }])
   end

--- a/backend/app/models/csv_export_helper.rb
+++ b/backend/app/models/csv_export_helper.rb
@@ -24,7 +24,8 @@ class CsvExportHelper
     survey_visit_longitude: 'Survey Visit Longitude',
     survey_visit_time: 'Survey Visit Time',
     surveyor_id: 'Surveyor ID',
-    surveyor_name: 'Surveyor Name'
+    surveyor_name: 'Surveyor Name',
+    survey_response_language_code: 'Language Code'
   }.freeze
 
   def self.home_hash(home)
@@ -78,7 +79,8 @@ class CsvExportHelper
       survey_visit_longitude: survey_visit.longitude,
       survey_visit_time: survey_visit.created_at.in_time_zone(EASTERN_TIMEZONE),
       surveyor_id: survey_visit.surveyor_id,
-      surveyor_name: survey_visit.surveyor&.full_name
+      surveyor_name: survey_visit.surveyor&.full_name,
+      survey_response_language_code: survey_visit.survey_response.language_code
     }
   end
   private_class_method :survey_visit_metadata_hash

--- a/backend/app/views/survey_visits/_survey_visit.json.jbuilder
+++ b/backend/app/views/survey_visits/_survey_visit.json.jbuilder
@@ -21,6 +21,7 @@ end
 if survey_visit.survey_response.present?
   json.survey_response do
     json.id survey_visit.survey_response.id
+    json.language_code survey_visit.survey_response.language_code
     json.survey_id survey_visit.survey_response.survey_id
     json.survey_answers survey_visit.survey_response.survey_answers do |sa|
       json.id sa.id

--- a/backend/db/migrate/20250420182258_add_language_code_to_survey_responses.rb
+++ b/backend/db/migrate/20250420182258_add_language_code_to_survey_responses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLanguageCodeToSurveyResponses < ActiveRecord::Migration[7.1]
+  def change
+    add_column :survey_responses, :language_code, :string
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_16_004117) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_20_182258) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -109,6 +109,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_16_004117) do
     t.datetime "updated_at", null: false
     t.string "ip"
     t.float "recaptcha_score"
+    t.string "language_code"
     t.index ["survey_id"], name: "index_survey_responses_on_survey_id"
     t.index ["survey_visit_id"], name: "index_survey_responses_on_survey_visit_id"
   end

--- a/backend/spec/models/csv_export_helper_spec.rb
+++ b/backend/spec/models/csv_export_helper_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe CsvExportHelper, type: :model do
         @survey_visit = create(:survey_visit, home: home, latitude: '33.333', longitude: '44.444')
       end
 
-      survey_response = create(:survey_response, survey: survey, survey_visit: @survey_visit)
+      survey_response = create(:survey_response, survey: survey, survey_visit: @survey_visit, language_code: 'es')
       create(:survey_answer, survey_question: survey_question, answers: ['Yes I would love a heat pump'],
                              survey_response: survey_response)
 
@@ -100,6 +100,7 @@ RSpec.describe CsvExportHelper, type: :model do
         home_zip_code: '02139',
         home_latitude: '42.32603453',
         home_longitude: '-71.08999264',
+        survey_response_language_code: 'es',
         "question_#{survey_question.id}".to_sym => 'Yes I would love a heat pump'
       }
 
@@ -154,6 +155,7 @@ RSpec.describe CsvExportHelper, type: :model do
         survey_visit_time: 'Survey Visit Time',
         surveyor_id: 'Surveyor ID',
         surveyor_name: 'Surveyor Name',
+        survey_response_language_code: 'Language Code',
         "question_#{survey_question.id}".to_sym => '"1. Heat pumps amirite?"'
       }
 

--- a/backend/spec/models/csv_exporter_spec.rb
+++ b/backend/spec/models/csv_exporter_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe CsvExporter, type: :model do
     let(:expected_standard_headers) do
       'Survey Visit ID,Home ID,Successful Export,Public Survey,Assignment ID,Assignment Surveyor IDs,' \
       'Assignment Surveyor Names,Street Number,Street Name,Unit Number,City,State,ZIP Code,Home Latitude,' \
-      'Home Longitude,Survey Visit Latitude,Survey Visit Longitude,Survey Visit Time,Surveyor ID,Surveyor Name'
+      'Home Longitude,Survey Visit Latitude,Survey Visit Longitude,Survey Visit Time,Surveyor ID,Surveyor Name,' \
+      'Language Code'
     end
 
     before do
@@ -20,8 +21,8 @@ RSpec.describe CsvExporter, type: :model do
       expected_headers = "#{expected_standard_headers},\"1. Do you want a heat pump?\"\n"
       expected_survey_visit = "#{@survey_visit.id},#{@home1.id},Yes,No,#{@assignment.id},#{@surveyor.id}," \
         'Luna Peters,1,Broadway,106,Cambridge,MA,02139,42.32603453,-71.08999264,42.3281053,-71.08229235,' \
-        "2025-02-13 12:30:20 -0500,#{@surveyor.id},Luna Peters,Yes I would love a heat pump\n"
-      expected_home = ",#{@home2.id},Yes,,,,,1,Broadway,106,Cambridge,MA,02139,42.32603453,-71.08999264,,,,,,\n"
+        "2025-02-13 12:30:20 -0500,#{@surveyor.id},Luna Peters,,Yes I would love a heat pump\n"
+      expected_home = ",#{@home2.id},Yes,,,,,1,Broadway,106,Cambridge,MA,02139,42.32603453,-71.08999264,,,,,,,\n"
 
       expected = expected_headers + expected_survey_visit + expected_home
       expect(actual).to eq(expected)
@@ -33,8 +34,8 @@ RSpec.describe CsvExporter, type: :model do
       actual = CsvExporter.new(survey: @survey).run
 
       expected_headers = "#{expected_standard_headers},\"1. Do you want a heat pump?\"\n"
-      expected_survey_visit = "#{@survey_visit.id},,No,,,,,,,,,,,,,,,,,,\n"
-      expected_home = ",#{@home2.id},Yes,,,,,1,Broadway,106,Cambridge,MA,02139,42.32603453,-71.08999264,,,,,,\n"
+      expected_survey_visit = "#{@survey_visit.id},,No,,,,,,,,,,,,,,,,,,,\n"
+      expected_home = ",#{@home2.id},Yes,,,,,1,Broadway,106,Cambridge,MA,02139,42.32603453,-71.08999264,,,,,,,\n"
 
       expected = expected_headers + expected_survey_visit + expected_home
       expect(actual).to eq(expected)
@@ -46,8 +47,8 @@ RSpec.describe CsvExporter, type: :model do
       actual = CsvExporter.new(survey: @survey).run
 
       expected_headers = "#{expected_standard_headers},\"1. Do you want a heat pump?\"\n"
-      expected_survey_visit = "#{@survey_visit.id},,No,,,,,,,,,,,,,,,,,,\n"
-      expected_home = ",#{@home2.id},No,,,,,,,,,,,,,,,,,,\n"
+      expected_survey_visit = "#{@survey_visit.id},,No,,,,,,,,,,,,,,,,,,,\n"
+      expected_home = ",#{@home2.id},No,,,,,,,,,,,,,,,,,,,\n"
 
       expected = expected_headers + expected_survey_visit + expected_home
       expect(actual).to eq(expected)

--- a/backend/spec/requests/admin/exports_spec.rb
+++ b/backend/spec/requests/admin/exports_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe '/admin/exports', type: :request do
         expected_body = 'Survey Visit ID,Home ID,Successful Export,Public Survey,Assignment ID,' \
         'Assignment Surveyor IDs,Assignment Surveyor Names,Street Number,Street Name,' \
         'Unit Number,City,State,ZIP Code,Home Latitude,Home Longitude,Survey Visit Latitude,' \
-        "Survey Visit Longitude,Survey Visit Time,Surveyor ID,Surveyor Name\n"
+        "Survey Visit Longitude,Survey Visit Time,Surveyor ID,Surveyor Name,Language Code\n"
 
         expect(response.body).to eq(expected_body)
       end

--- a/backend/spec/requests/survey_visits_spec.rb
+++ b/backend/spec/requests/survey_visits_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe '/survey_visits', type: :request do
       longitude: '-71.9419063',
       survey_response_attributes: {
         survey_id: survey.id,
+        language_code: 'es',
         survey_answers_attributes: [
           {
             survey_question_id: survey_question.id,
@@ -61,6 +62,17 @@ RSpec.describe '/survey_visits', type: :request do
       survey_visit = SurveyVisit.create! valid_attributes
       get survey_visit_url(survey_visit), as: :json
       expect(response).to be_successful
+
+      survey_visit_json = JSON.parse(response.body)
+      expect(survey_visit_json['id']).to eq(survey_visit.id)
+      expect(survey_visit_json['surveyor_id']).to eq(surveyor.id)
+      expect(survey_visit_json['home_id']).to eq(home.id)
+      expect(survey_visit_json['survey_response']['survey_id']).to eq(survey.id)
+      expect(survey_visit_json['survey_response']['language_code']).to eq('es')
+
+      survey_answer = survey_visit_json['survey_response']['survey_answers'][0]
+      expect(survey_answer['survey_question_id']).to eq(survey_question.id)
+      expect(survey_answer['answers']).to eq(%w[Foo Bar])
     end
   end
 
@@ -86,6 +98,7 @@ RSpec.describe '/survey_visits', type: :request do
 
         survey_response = survey_visit.survey_response
         expect(survey_response).to be_present
+        expect(survey_response.language_code).to eq('es')
         expect(survey_response.survey_id).to eq(survey.id)
         expect(survey_response.survey_answers.count).to eq(1)
 


### PR DESCRIPTION
Note: Could potentially add validation on survey response that the language code is one of the ones we support - that way we don't end up with a situation where a user inputs a bad value, and then the front end uses it to request the correct language survey later. But meh, doesn't seem too important either way