### PR TITLE
Frontend add survey mode param

### DIFF
--- a/frontend/front/src/api/apiSlice.js
+++ b/frontend/front/src/api/apiSlice.js
@@ -2,7 +2,6 @@ import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 import { AUTHORIZATION_HEADER } from "../features/login/loginUtils";
 import { transformSurveyorKeys } from "../features/surveyor/surveyorUtils";
-import { validateLanguage } from "../util/surveyUtils";
 
 const baseUrl = process.env.REACT_APP_API_URL || "http://localhost:3000";
 
@@ -141,15 +140,21 @@ export const apiSlice = createApi({
       ],
     }),
     getSurveyStructure: builder.query({
-      query: (id) => {
-        const validatedLangPref = validateLanguage();
+      query: ({ id, langPref, surveyMode }) => {
         return {
           url: `/surveys/${id}`,
           method: "GET",
-          params: { langPref: validatedLangPref },
+          params: { langPref, survey_mode: surveyMode },
         };
       },
-      providesTags: (result, error, arg) => [{ type: "Survey", id: arg }],
+      providesTags: (result, error, arg) => [
+        {
+          type: "Survey",
+          id: arg.id,
+          langPref: arg.langPref,
+          surveyMode: arg.surveyMode,
+        },
+      ],
     }),
     createSurvey: builder.mutation({
       query: (survey) => ({

--- a/frontend/front/src/components/SurveyComponent/SurveyComponent.js
+++ b/frontend/front/src/components/SurveyComponent/SurveyComponent.js
@@ -300,13 +300,14 @@ const SurveyComponent = ({
 
 // makes sure data fetching happens BEFORE the form is loaded, so that the form hook can be initialized with the correct default data
 const SurveyComponentWrapper = forwardRef((props, ref) => {
-  const { defaultData, style, activeHome, surveyId } = props;
+  const { defaultData, style, activeHome, surveyId, langPref, surveyMode } =
+    props;
 
   const {
     data: surveyStructure,
     isError: isSurveyError,
     isLoading: isSurveyLoading,
-  } = useGetSurveyStructureQuery(surveyId);
+  } = useGetSurveyStructureQuery({ id: surveyId, langPref, surveyMode });
 
   const formDefault = useMemo(() => {
     if (defaultData) {

--- a/frontend/front/src/components/SurveyComponent/SurveyVisitProfile.js
+++ b/frontend/front/src/components/SurveyComponent/SurveyVisitProfile.js
@@ -1,0 +1,76 @@
+import { Container, Typography } from "@mui/material";
+import { useMemo } from "react";
+import { useGetSurveyVisitQuery } from "../../api/apiSlice";
+import { useParams } from "react-router-dom";
+import Loader from "../Loader";
+import { SurveyError } from "./SurveyStructureError";
+import { formatISODate } from "../DateUtils";
+import { houseToString } from "../AddressUtils";
+import { buildDataFromSurveyAnswers } from "../../util/surveyUtils";
+
+const SurveyProfile = ({ renderSurvey }) => {
+  const { uid: surveyVisitId } = useParams();
+
+  const { data: surveyVisit, error: surveyVisitError } =
+    useGetSurveyVisitQuery(surveyVisitId);
+
+  const title = useMemo(
+    () => (surveyVisit ? `${houseToString(surveyVisit.home)}` : "Loading..."),
+    [surveyVisit]
+  );
+
+  const completedTime = useMemo(
+    () =>
+      surveyVisit
+        ? `Completed at: ${formatISODate(surveyVisit.created_at)}`
+        : "Loading...",
+    [surveyVisit]
+  );
+
+  const surveyAnswers = useMemo(
+    () =>
+      surveyVisit?.survey_response
+        ? buildDataFromSurveyAnswers(
+            surveyVisit?.survey_response?.survey_answers
+          )
+        : [],
+    [surveyVisit]
+  );
+
+  const langPref = useMemo(
+    () => surveyVisit?.survey_response?.language_code || "en",
+    [surveyVisit]
+  );
+
+  const surveyMode = useMemo(
+    () => (surveyVisit?.surveyor_id ? "offline" : "online"),
+    [surveyVisit]
+  );
+
+  return (
+    <Container>
+      <Typography variant="h5" mt={2}>
+        {title}
+      </Typography>
+      <Typography variant="subtitle1" mt={2}>
+        {completedTime}
+      </Typography>
+      {surveyVisit ? (
+        renderSurvey({
+          defaultData: surveyAnswers,
+          activeHome: surveyVisit.home,
+          surveyId: surveyVisit.survey_response.survey_id,
+          readOnly: true,
+          langPref,
+          surveyMode,
+        })
+      ) : surveyVisitError ? (
+        <SurveyError />
+      ) : (
+        <Loader />
+      )}
+    </Container>
+  );
+};
+
+export default SurveyProfile;

--- a/frontend/front/src/components/SurveyComponent/__tests__/SurveyComponent.test.js
+++ b/frontend/front/src/components/SurveyComponent/__tests__/SurveyComponent.test.js
@@ -21,6 +21,9 @@ const DEFAULT_TEST_SURVEY_CACHE_KEY = buildSurveyCacheKey(
 );
 const DEFAULT_TEST_DEFAULT_SURVEY_DATA =
   buildDefaultDataFromSurveyStructure(DEFAULT_TEST_SURVEY);
+const DEFAULT_TEST_LANG_PREF = "en";
+const EXPECTED_TEST_SURVEY_OPTIONS = ["online", "offline"];
+const DEFAULT_TEST_SURVEY_MODE = "online";
 
 describe("SurveyComponent", () => {
   beforeEach(() => {
@@ -28,9 +31,27 @@ describe("SurveyComponent", () => {
 
     jest
       .spyOn(apiSlice, "useGetSurveyStructureQuery")
-      .mockImplementation((id) => {
+      .mockImplementation(({ id, langPref, surveyMode }) => {
         const survey = surveys.find((s) => `${s.id}` === `${id}`);
-        return { data: survey, error: !survey };
+        if (
+          !langPref ||
+          !surveyMode ||
+          langPref !== DEFAULT_TEST_LANG_PREF ||
+          !EXPECTED_TEST_SURVEY_OPTIONS.includes(surveyMode)
+        ) {
+          return {
+            error: true,
+            isError: true,
+            isLoading: false,
+            data: undefined,
+          };
+        }
+        return {
+          data: survey,
+          error: !survey,
+          isError: !survey,
+          isLoading: false,
+        };
       });
   });
 
@@ -50,6 +71,8 @@ describe("SurveyComponent", () => {
     render(
       <MemoryRouter>
         <SurveyComponent
+          langPref="en"
+          surveyMode="online"
           submitSurvey={jest.fn()}
           isLoading={false}
           activeHome={DEFAULT_TEST_HOME}
@@ -70,6 +93,8 @@ describe("SurveyComponent", () => {
     render(
       <MemoryRouter>
         <SurveyComponent
+          langPref="en"
+          surveyMode="online"
           submitSurvey={jest.fn()}
           isLoading={false}
           activeHome={DEFAULT_TEST_HOME}
@@ -118,6 +143,8 @@ describe("SurveyComponent", () => {
     render(
       <MemoryRouter>
         <SurveyComponent
+          langPref="en"
+          surveyMode="online"
           submitSurvey={mockSubmit}
           isLoading={false}
           activeHome={DEFAULT_TEST_HOME}
@@ -161,6 +188,8 @@ describe("SurveyComponent", () => {
     render(
       <MemoryRouter>
         <SurveyComponent
+          langPref="en"
+          surveyMode="online"
           submitSurvey={mockSubmit}
           isLoading={false}
           activeHome={DEFAULT_TEST_HOME}
@@ -183,6 +212,8 @@ describe("SurveyComponent", () => {
     const { container } = render(
       <MemoryRouter>
         <SurveyComponent
+          langPref="en"
+          surveyMode="online"
           submitSurvey={jest.fn()}
           isLoading={false}
           activeHome={DEFAULT_TEST_HOME}
@@ -194,5 +225,83 @@ describe("SurveyComponent", () => {
 
     expect(container).toMatchSnapshot();
     expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it("should show error message when langPref is missing", () => {
+    render(
+      <MemoryRouter>
+        <SurveyComponent
+          submitSurvey={jest.fn()}
+          isLoading={false}
+          activeHome={DEFAULT_TEST_HOME}
+          surveyId={DEFAULT_TEST_SURVEY.id}
+          formSpacing={5}
+          surveyMode={DEFAULT_TEST_SURVEY_MODE}
+        />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByText("Encountered an error while loading the survey.")
+    ).toBeInTheDocument();
+  });
+
+  it("should show error message when langPref is incorrect", () => {
+    render(
+      <MemoryRouter>
+        <SurveyComponent
+          submitSurvey={jest.fn()}
+          isLoading={false}
+          activeHome={DEFAULT_TEST_HOME}
+          surveyId={DEFAULT_TEST_SURVEY.id}
+          formSpacing={5}
+          surveyMode={DEFAULT_TEST_SURVEY_MODE}
+          langPref="fr"
+        />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByText("Encountered an error while loading the survey.")
+    ).toBeInTheDocument();
+  });
+
+  it("should show error message when surveyMode is missing", () => {
+    render(
+      <MemoryRouter>
+        <SurveyComponent
+          submitSurvey={jest.fn()}
+          isLoading={false}
+          activeHome={DEFAULT_TEST_HOME}
+          surveyId={DEFAULT_TEST_SURVEY.id}
+          formSpacing={5}
+          langPref={DEFAULT_TEST_LANG_PREF}
+        />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByText("Encountered an error while loading the survey.")
+    ).toBeInTheDocument();
+  });
+
+  it("should show error message when surveyMode is not in allowed options", () => {
+    render(
+      <MemoryRouter>
+        <SurveyComponent
+          submitSurvey={jest.fn()}
+          isLoading={false}
+          activeHome={DEFAULT_TEST_HOME}
+          surveyId={DEFAULT_TEST_SURVEY.id}
+          formSpacing={5}
+          langPref={DEFAULT_TEST_LANG_PREF}
+          surveyMode="invalid_mode"
+        />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByText("Encountered an error while loading the survey.")
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/front/src/pages/Admin/AdminContainer.js
+++ b/frontend/front/src/pages/Admin/AdminContainer.js
@@ -8,9 +8,10 @@ import Home from "./home/Home";
 import HomeProfile from "./home/HomeProfile";
 import Nav from "./nav/Nav";
 import React, { useMemo } from "react";
+import { AdminSurvey } from "./component/AdminSurvey";
 import Survey from "./survey/Survey";
 import SurveyEditor from "./survey/SurveyProfile";
-import SurveyVisit from "./home/SurveyVisitProfile";
+import SurveyVisitProfile from "../../components/SurveyComponent/SurveyVisitProfile";
 import Unassigned from "./assignment/Unassigned";
 import User from "./user/User";
 import UserProfile from "./user/UserProfile";
@@ -67,7 +68,14 @@ const AdminContainer = () => {
           <Route path={routes.ADMIN_SURVEY} element={<Survey />} />
           <Route path={routes.ADMIN_ASSIGNMENT} element={<Assignment />} />
           <Route path={routes.adminSurveyEdit()} element={<SurveyEditor />} />
-          <Route path={routes.adminSurveyVisit()} element={<SurveyVisit />} />
+          <Route
+            path={routes.adminSurveyVisit()}
+            element={
+              <SurveyVisitProfile
+                renderSurvey={(props) => <AdminSurvey {...props} />}
+              />
+            }
+          />
           <Route
             path={routes.adminAssignmentProfile()}
             element={<AssignProfile />}

--- a/frontend/front/src/pages/Admin/component/AdminSurvey.js
+++ b/frontend/front/src/pages/Admin/component/AdminSurvey.js
@@ -2,10 +2,5 @@ import React from "react";
 import SurveyComponent from "../../../components/SurveyComponent/SurveyComponent";
 
 export const AdminSurvey = (props) => (
-  <SurveyComponent
-    {...props}
-    formSpacing={2}
-    langPref="en"
-    surveyMode="online"
-  />
+  <SurveyComponent {...props} formSpacing={2} />
 );

--- a/frontend/front/src/pages/Admin/component/AdminSurvey.js
+++ b/frontend/front/src/pages/Admin/component/AdminSurvey.js
@@ -2,5 +2,10 @@ import React from "react";
 import SurveyComponent from "../../../components/SurveyComponent/SurveyComponent";
 
 export const AdminSurvey = (props) => (
-  <SurveyComponent {...props} formSpacing={2} />
+  <SurveyComponent
+    {...props}
+    formSpacing={2}
+    langPref="en"
+    surveyMode="online"
+  />
 );

--- a/frontend/front/src/pages/Admin/home/SurveyVisitProfile.js
+++ b/frontend/front/src/pages/Admin/home/SurveyVisitProfile.js
@@ -1,9 +1,6 @@
 import { Container, Typography } from "@mui/material";
 import React, { useMemo } from "react";
-import {
-  useGetSurveyStructureQuery,
-  useGetSurveyVisitQuery,
-} from "../../../api/apiSlice";
+import { useGetSurveyVisitQuery } from "../../../api/apiSlice";
 import { useParams } from "react-router-dom";
 import { AdminSurvey } from "../component/AdminSurvey";
 import Loader from "../../../components/Loader";
@@ -17,11 +14,6 @@ const SurveyProfile = () => {
 
   const { data: surveyVisit, error: surveyVisitError } =
     useGetSurveyVisitQuery(surveyVisitId);
-
-  const { data: { survey_questions: surveyQuestions } = {} } =
-    useGetSurveyStructureQuery(surveyVisit?.survey_response?.survey_id, {
-      skip: !surveyVisit,
-    });
 
   const title = useMemo(
     () => (surveyVisit ? `${houseToString(surveyVisit.home)}` : "Loading..."),
@@ -40,11 +32,10 @@ const SurveyProfile = () => {
     () =>
       surveyVisit?.survey_response
         ? buildDataFromSurveyAnswers(
-            surveyVisit?.survey_response?.survey_answers,
-            surveyQuestions?.length
+            surveyVisit?.survey_response?.survey_answers
           )
         : [],
-    [surveyVisit, surveyQuestions]
+    [surveyVisit]
   );
 
   return (

--- a/frontend/front/src/pages/Public/Components/PublicSurvey.js
+++ b/frontend/front/src/pages/Public/Components/PublicSurvey.js
@@ -1,13 +1,21 @@
 import React, { forwardRef } from "react";
 import SurveyComponent from "../../../components/SurveyComponent/SurveyComponent";
+import { useTranslation } from "react-i18next";
 
 const PUBLIC_SURVEY_ID = "1";
 
-export const PublicSurvey = forwardRef((props, ref) => (
-  <SurveyComponent
-    {...props}
-    surveyId={PUBLIC_SURVEY_ID}
-    formSpacing={5}
-    ref={ref}
-  />
-));
+export const PublicSurvey = forwardRef((props, ref) => {
+  const {
+    i18n: { language },
+  } = useTranslation();
+  return (
+    <SurveyComponent
+      {...props}
+      surveyId={PUBLIC_SURVEY_ID}
+      formSpacing={5}
+      ref={ref}
+      langPref={language}
+      surveyMode="offline"
+    />
+  );
+});

--- a/frontend/front/src/pages/Public/Components/PublicSurvey.js
+++ b/frontend/front/src/pages/Public/Components/PublicSurvey.js
@@ -15,7 +15,7 @@ export const PublicSurvey = forwardRef((props, ref) => {
       formSpacing={5}
       ref={ref}
       langPref={language}
-      surveyMode="offline"
+      surveyMode="online"
     />
   );
 });

--- a/frontend/front/src/pages/Surveyor/Components/CompletedSurvey.js
+++ b/frontend/front/src/pages/Surveyor/Components/CompletedSurvey.js
@@ -1,0 +1,10 @@
+import SurveyComponent from "../../../components/SurveyComponent/SurveyComponent";
+
+export const CompletedSurvey = (props) => (
+  <SurveyComponent
+    {...props}
+    formSpacing={2}
+    langPref="en"
+    surveyMode="offline"
+  />
+);

--- a/frontend/front/src/pages/Surveyor/Components/SurveyorSurvey.js
+++ b/frontend/front/src/pages/Surveyor/Components/SurveyorSurvey.js
@@ -26,6 +26,8 @@ export const SurveyorSurvey = forwardRef((props, ref) => {
         formSpacing={8}
         ref={ref}
         styles={styles}
+        langPref="en"
+        surveyMode="online"
       />
     </>
   );

--- a/frontend/front/src/pages/Surveyor/Components/SurveyorSurvey.js
+++ b/frontend/front/src/pages/Surveyor/Components/SurveyorSurvey.js
@@ -27,7 +27,7 @@ export const SurveyorSurvey = forwardRef((props, ref) => {
         ref={ref}
         styles={styles}
         langPref="en"
-        surveyMode="online"
+        surveyMode="offline"
       />
     </>
   );

--- a/frontend/front/src/pages/Surveyor/SurveyorContainer.js
+++ b/frontend/front/src/pages/Surveyor/SurveyorContainer.js
@@ -1,7 +1,6 @@
 import { Navigate, Route, Routes } from "react-router-dom";
 
 import { Box } from "@mui/material";
-import React from "react";
 import { useSelector } from "react-redux";
 import { useGetSurveyorQuery } from "../../api/apiSlice";
 import {
@@ -9,12 +8,13 @@ import {
   selectIsLoggedIn,
 } from "../../features/login/loginSlice";
 import { ProtectedInactive } from "../../routing/ProtectedInactive";
+import { CompletedSurvey } from "./Components/CompletedSurvey";
 import InactiveSurveyor from "./Components/InactiveSurveyor";
 import Account from "./account/Account";
 import Dashboard from "./dashboard/Dashboard";
 import HouseProfile from "./houseProfile/HouseProfile";
 import Nav from "./nav/Nav";
-import SurveyVisit from "../../pages/Admin/home/SurveyVisitProfile";
+import SurveyVisitProfile from "../../components/SurveyComponent/SurveyVisitProfile";
 
 const SurveyorContainer = () => {
   const isLoggedIn = useSelector(selectIsLoggedIn);
@@ -29,10 +29,17 @@ const SurveyorContainer = () => {
           <Route
             element={<ProtectedInactive userStatus={surveyorData?.status} />}
           >
-            <Route path="dashboard" element={<Dashboard />}></Route>
-            <Route path="account" element={<Account />}></Route>
-            <Route path="house/:id" element={<HouseProfile />}></Route>
-            <Route path="survey/:uid" element={<SurveyVisit />}></Route>
+            <Route path="dashboard" element={<Dashboard />} />
+            <Route path="account" element={<Account />} />
+            <Route path="house/:id" element={<HouseProfile />} />
+            <Route
+              path="survey/:uid"
+              element={
+                <SurveyVisitProfile
+                  renderSurvey={(props) => <CompletedSurvey {...props} />}
+                />
+              }
+            />
             <Route path="/*" element={<Navigate to="/surveyor/dashboard" />} />
           </Route>
           <Route path="inactive" element={<InactiveSurveyor />} />

--- a/frontend/front/src/util/surveyUtils.js
+++ b/frontend/front/src/util/surveyUtils.js
@@ -1,14 +1,3 @@
-// Current supported survey languages
-const supportedLanguages = ["en-US"];
-
-export const validateLanguage = () => {
-  const langPref = localStorage.getItem("langPref");
-  if (typeof langPref !== "string") {
-    return "en-US";
-  }
-  return supportedLanguages.includes(langPref) ? langPref : "en-US";
-};
-
 export const buildSurveyCacheKey = (surveyId, homeId) =>
   `survey${surveyId}-home${homeId}`;
 
@@ -20,22 +9,12 @@ export const buildDefaultDataFromSurveyStructure = (surveyStructure) =>
     }),
     {}
   );
-export const buildDataFromSurveyAnswers = (
-  surveyAnswers = [],
-  numberOfQuestions = 0
-) => {
-  const data = {};
 
-  for (let i = 1; i <= numberOfQuestions; i++) {
-    data[i] = "";
-  }
-
-  surveyAnswers.forEach((curr) => {
+export const buildDataFromSurveyAnswers = (surveyAnswers = []) =>
+  surveyAnswers.reduce((data, curr) => {
     data[curr.survey_question_id] = curr.answers;
-  });
-
-  return data;
-};
+    return data;
+  }, {});
 
 export const buildSurveyVisitData = (
   answers,


### PR DESCRIPTION
- add ```survey_mode``` param to backend query and update query calls
- update props for ```SurveyorSurvey```, ```PublicSurvey``` and ```AdminSurvey``` to use their respective language and survey mode settings
- add tests for langPref and surveyMode to ```SurveyComponent```
- remove second arg form ```buildDataFromSurveyAnswers``` util function and remove unneeded ```useGetSurveyStructureQuery``` query for ```SurveyVisitProfile``` as the length of query result is only used. ```useGetSurveyVisitQuery``` can provide same information.