### PR TITLE
Frontend remove language region code

### DIFF
--- a/frontend/front/src/pages/Public/Components/LangPrefDropdown.js
+++ b/frontend/front/src/pages/Public/Components/LangPrefDropdown.js
@@ -101,7 +101,7 @@ const LangPrefDropdown = () => {
     }
 
     // Update displayed language
-    setLangDisplay(langMap[lang]);
+    setLangDisplay(dropdownLangNames[lang]);
   };
 
   return (

--- a/frontend/front/src/pages/Public/Components/LangPrefDropdown.js
+++ b/frontend/front/src/pages/Public/Components/LangPrefDropdown.js
@@ -144,7 +144,7 @@ const LangPrefDropdown = () => {
               key={lang}
               variant="navLinks"
               onClick={() => {
-                handleChangeLanguage(lang, langMap[lang]);
+                handleChangeLanguage(lang);
                 handleCloseMore();
               }}
             >

--- a/frontend/front/src/pages/Public/Components/LangPrefDropdown.js
+++ b/frontend/front/src/pages/Public/Components/LangPrefDropdown.js
@@ -17,10 +17,17 @@ const LangPrefDropdown = () => {
   const location = useLocation();
 
   const langMap = {
-    "en-US": `🇺🇸 ${t("public.global-labels.locales.english")}`,
-    "ht-CR": `🇭🇹 ${t("public.global-labels.locales.creole")}`,
-    "pt-BR": `🇧🇷 ${t("public.global-labels.locales.portuguese")}`,
-    "es-US": `🇪🇸 ${t("public.global-labels.locales.spanish")}`,
+    en: `🇺🇸 ${t("public.global-labels.locales.english")}`,
+    ht: `🇭🇹 ${t("public.global-labels.locales.creole")}`,
+    pt: `🇧🇷 ${t("public.global-labels.locales.portuguese")}`,
+    es: `🇪🇸 ${t("public.global-labels.locales.spanish")}`,
+  };
+
+  const dropdownLangNames = {
+    en: "English",
+    ht: "Kreyòl",
+    pt: "Português",
+    es: "Español",
   };
 
   useEffect(() => {
@@ -32,15 +39,15 @@ const LangPrefDropdown = () => {
     const isPublicRoute = location.pathname.includes("public");
 
     if (isPublicRoute) {
-      // Get language preference from localStorage or default to 'en-US'
-      queryLang = localStorage.getItem("langPref") || "en-US";
+      // Get language preference from localStorage or default to 'en'
+      queryLang = localStorage.getItem("langPref") || "en";
 
       if (!localStorage.getItem("langPref")) {
-        localStorage.setItem("langPref", "en-US");
+        localStorage.setItem("langPref", "en");
       }
 
       // Update or remove 'langPref' query param based on language
-      if (queryLang !== "en-US") {
+      if (queryLang !== "en") {
         params.set("langPref", queryLang);
       } else {
         params.delete("langPref");
@@ -85,7 +92,7 @@ const LangPrefDropdown = () => {
 
     // Update or remove 'langPref' query param based on route and language
     if (url.pathname.includes("public")) {
-      if (lang !== "en-US") {
+      if (lang !== "en") {
         url.searchParams.set("langPref", lang);
       } else {
         url.searchParams.delete("langPref");
@@ -109,7 +116,7 @@ const LangPrefDropdown = () => {
         sx={{ color: "var(--color-text-1)" }}
       >
         <Typography variant="navLinks">
-          {langDisplay === undefined ? "English" : language}
+          {langDisplay === undefined ? "English" : dropdownLangNames[language]}
         </Typography>
       </Button>
 

--- a/frontend/front/src/pages/Public/Libs/i18n.js
+++ b/frontend/front/src/pages/Public/Libs/i18n.js
@@ -5,7 +5,7 @@ import ptTranslations from "../locales/pt-BR.json";
 import esTranslations from "../locales/es-419.json";
 import htTranslations from "../locales/ht.json";
 
-const userLangPref = localStorage.getItem("langPref") || "en-US";
+const userLangPref = localStorage.getItem("langPref") || "en";
 
 // configuration for i18next library
 i18next
@@ -15,7 +15,7 @@ i18next
     fallbackLng: ["en", "es"], // fallback language
     resources: {
       en: { translation: { ...enTranslations } }, // English - United States
-      "pt-BR": { translation: { ...ptTranslations } }, // Portuguese - Brazil
+      pt: { translation: { ...ptTranslations } }, // Portuguese - Brazil
       es: { translation: { ...esTranslations } }, // Spanish - Latin America
       ht: { translation: { ...htTranslations } }, // Haitian Creole - Haiti
     },


### PR DESCRIPTION
- remove region codes from language picker component
- use more human readable values ("English","Kreyòl","Português","Español") for dropdown