### PR TITLE
Validate value of language code on survey response

### DIFF
--- a/backend/app/models/survey_response.rb
+++ b/backend/app/models/survey_response.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 class SurveyResponse < ApplicationRecord
+  SUPPORTED_LANGUAGE_CODES = %w[en es ht pt].freeze
+
   belongs_to :survey
   belongs_to :survey_visit
   has_many :survey_answers, dependent: :destroy
   accepts_nested_attributes_for :survey_answers
+
+  validates :language_code, inclusion: { in: SUPPORTED_LANGUAGE_CODES }, allow_nil: true
 end

--- a/backend/spec/models/survey_response_spec.rb
+++ b/backend/spec/models/survey_response_spec.rb
@@ -3,5 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe SurveyResponse, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'validates language code is an accepted value if not null' do
+    survey_response = build(:survey_response, language_code: 'foo')
+    survey_response.valid?
+    expect(survey_response.errors.full_messages).to include('Language code is not included in the list')
+  end
 end


### PR DESCRIPTION
With this PR: https://github.com/codeforboston/urban-league-heat-pump-accelerator/commit/89f63aa84b5e3c27a4e839be1c590cdade097e38 where we added language code to survey response, we discussed that we should validate the value of language code.