### PR TITLE
Add calculated field for distance between survey visit and home

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -9,6 +9,7 @@ gem 'bootsnap', require: false
 gem 'devise'
 gem 'devise-jwt'
 gem 'faraday'
+gem 'geocoder'
 gem 'http_accept_language'
 gem 'jbuilder'
 gem 'net-imap', '>= 0.5.7'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
+    csv (3.3.4)
     date (3.4.1)
     debug (1.9.2)
       irb (~> 1.10)
@@ -133,6 +134,9 @@ GEM
       logger
     faraday-net_http (3.1.0)
       net-http
+    geocoder (1.8.5)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     http_accept_language (2.1.1)
@@ -342,6 +346,7 @@ DEPENDENCIES
   devise-jwt
   factory_bot_rails
   faraday
+  geocoder
   http_accept_language
   jbuilder
   net-imap (>= 0.5.7)

--- a/backend/app/models/csv_export_helper.rb
+++ b/backend/app/models/csv_export_helper.rb
@@ -3,6 +3,7 @@
 class CsvExportHelper
   SURVEY_LANG = 'en'
   SURVEY_MODE = 'online'
+  SURVEY_VISIT_DISTANCE_FROM_HOME_DECIMAL = 5
   EASTERN_TIMEZONE = 'Eastern Time (US & Canada)'
   CSV_STATIC_HEADERS = {
     survey_visit_id: 'Survey Visit ID',
@@ -23,6 +24,7 @@ class CsvExportHelper
     survey_visit_latitude: 'Survey Visit Latitude',
     survey_visit_longitude: 'Survey Visit Longitude',
     survey_visit_time: 'Survey Visit Time',
+    survey_visit_distance_from_home: 'Survey Visit Distance From Home (miles)',
     surveyor_id: 'Surveyor ID',
     surveyor_name: 'Surveyor Name',
     survey_response_language_code: 'Language Code'
@@ -78,6 +80,7 @@ class CsvExportHelper
       survey_visit_latitude: survey_visit.latitude,
       survey_visit_longitude: survey_visit.longitude,
       survey_visit_time: survey_visit.created_at.in_time_zone(EASTERN_TIMEZONE),
+      survey_visit_distance_from_home: survey_visit.distance_from_home.round(SURVEY_VISIT_DISTANCE_FROM_HOME_DECIMAL),
       surveyor_id: survey_visit.surveyor_id,
       surveyor_name: survey_visit.surveyor&.full_name,
       survey_response_language_code: survey_visit.survey_response.language_code

--- a/backend/app/models/survey_visit.rb
+++ b/backend/app/models/survey_visit.rb
@@ -1,12 +1,24 @@
 # frozen_string_literal: true
 
+require 'geocoder'
+
 class SurveyVisit < ApplicationRecord
   belongs_to :surveyor, optional: true
   belongs_to :home
   has_one :survey_response
   accepts_nested_attributes_for :survey_response
+  before_create :calculate_distance_from_home
 
   def public_survey?
     surveyor_id.blank?
+  end
+
+  def calculate_distance_from_home
+    return unless latitude.present? && longitude.present? && home.latitude.present? && home.longitude.present?
+
+    point1 = [latitude, longitude]
+    point2 = [home.latitude, home.longitude]
+
+    self.distance_from_home = Geocoder::Calculations.distance_between(point1, point2)
   end
 end

--- a/backend/db/migrate/20250530172636_add_distance_from_home_to_survey_visits.rb
+++ b/backend/db/migrate/20250530172636_add_distance_from_home_to_survey_visits.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDistanceFromHomeToSurveyVisits < ActiveRecord::Migration[7.1]
+  def change
+    add_column :survey_visits, :distance_from_home, :decimal
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_20_182258) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_30_172636) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -121,6 +121,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_20_182258) do
     t.bigint "surveyor_id"
     t.string "latitude"
     t.string "longitude"
+    t.decimal "distance_from_home"
     t.index ["home_id"], name: "index_survey_visits_on_home_id"
     t.index ["surveyor_id"], name: "index_survey_visits_on_surveyor_id"
   end

--- a/backend/spec/models/csv_export_helper_spec.rb
+++ b/backend/spec/models/csv_export_helper_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe CsvExportHelper, type: :model do
 
       # Freeze time so we can test survey_visit created_at
       Timecop.freeze(freeze_time) do
-        @survey_visit = create(:survey_visit, home: home, latitude: '33.333', longitude: '44.444')
+        @survey_visit = create(:survey_visit, home: home, latitude: '42.3261', longitude: '-71.0898')
       end
 
       survey_response = create(:survey_response, survey: survey, survey_visit: @survey_visit, language_code: 'es')
@@ -86,9 +86,10 @@ RSpec.describe CsvExportHelper, type: :model do
       expected = {
         survey_visit_id: @survey_visit.id,
         public_survey: 'Yes',
-        survey_visit_latitude: '33.333',
-        survey_visit_longitude: '44.444',
+        survey_visit_latitude: '42.3261',
+        survey_visit_longitude: '-71.0898',
         survey_visit_time: freeze_time.in_time_zone('Eastern Time (US & Canada)'),
+        survey_visit_distance_from_home: 0.01083,
         surveyor_id: nil,
         surveyor_name: nil,
         home_id: home.id,
@@ -153,6 +154,7 @@ RSpec.describe CsvExportHelper, type: :model do
         survey_visit_latitude: 'Survey Visit Latitude',
         survey_visit_longitude: 'Survey Visit Longitude',
         survey_visit_time: 'Survey Visit Time',
+        survey_visit_distance_from_home: 'Survey Visit Distance From Home (miles)',
         surveyor_id: 'Surveyor ID',
         surveyor_name: 'Surveyor Name',
         survey_response_language_code: 'Language Code',

--- a/backend/spec/models/csv_exporter_spec.rb
+++ b/backend/spec/models/csv_exporter_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe CsvExporter, type: :model do
     let(:expected_standard_headers) do
       'Survey Visit ID,Home ID,Successful Export,Public Survey,Assignment ID,Assignment Surveyor IDs,' \
       'Assignment Surveyor Names,Street Number,Street Name,Unit Number,City,State,ZIP Code,Home Latitude,' \
-      'Home Longitude,Survey Visit Latitude,Survey Visit Longitude,Survey Visit Time,Surveyor ID,Surveyor Name,' \
-      'Language Code'
+      'Home Longitude,Survey Visit Latitude,Survey Visit Longitude,Survey Visit Time,' \
+      'Survey Visit Distance From Home (miles),Surveyor ID,Surveyor Name,Language Code'
     end
 
     before do
@@ -21,8 +21,8 @@ RSpec.describe CsvExporter, type: :model do
       expected_headers = "#{expected_standard_headers},\"1. Do you want a heat pump?\"\n"
       expected_survey_visit = "#{@survey_visit.id},#{@home1.id},Yes,No,#{@assignment.id},#{@surveyor.id}," \
         'Luna Peters,1,Broadway,106,Cambridge,MA,02139,42.32603453,-71.08999264,42.3281053,-71.08229235,' \
-        "2025-02-13 12:30:20 -0500,#{@surveyor.id},Luna Peters,,Yes I would love a heat pump\n"
-      expected_home = ",#{@home2.id},Yes,,,,,1,Broadway,106,Cambridge,MA,02139,42.32603453,-71.08999264,,,,,,,\n"
+        "2025-02-13 12:30:20 -0500,0.41856,#{@surveyor.id},Luna Peters,,Yes I would love a heat pump\n"
+      expected_home = ",#{@home2.id},Yes,,,,,1,Broadway,106,Cambridge,MA,02139,42.32603453,-71.08999264,,,,,,,,\n"
 
       expected = expected_headers + expected_survey_visit + expected_home
       expect(actual).to eq(expected)
@@ -34,8 +34,8 @@ RSpec.describe CsvExporter, type: :model do
       actual = CsvExporter.new(survey: @survey).run
 
       expected_headers = "#{expected_standard_headers},\"1. Do you want a heat pump?\"\n"
-      expected_survey_visit = "#{@survey_visit.id},,No,,,,,,,,,,,,,,,,,,,\n"
-      expected_home = ",#{@home2.id},Yes,,,,,1,Broadway,106,Cambridge,MA,02139,42.32603453,-71.08999264,,,,,,,\n"
+      expected_survey_visit = "#{@survey_visit.id},,No,,,,,,,,,,,,,,,,,,,,\n"
+      expected_home = ",#{@home2.id},Yes,,,,,1,Broadway,106,Cambridge,MA,02139,42.32603453,-71.08999264,,,,,,,,\n"
 
       expected = expected_headers + expected_survey_visit + expected_home
       expect(actual).to eq(expected)
@@ -47,8 +47,8 @@ RSpec.describe CsvExporter, type: :model do
       actual = CsvExporter.new(survey: @survey).run
 
       expected_headers = "#{expected_standard_headers},\"1. Do you want a heat pump?\"\n"
-      expected_survey_visit = "#{@survey_visit.id},,No,,,,,,,,,,,,,,,,,,,\n"
-      expected_home = ",#{@home2.id},No,,,,,,,,,,,,,,,,,,,\n"
+      expected_survey_visit = "#{@survey_visit.id},,No,,,,,,,,,,,,,,,,,,,,\n"
+      expected_home = ",#{@home2.id},No,,,,,,,,,,,,,,,,,,,,\n"
 
       expected = expected_headers + expected_survey_visit + expected_home
       expect(actual).to eq(expected)

--- a/backend/spec/models/survey_visit_spec.rb
+++ b/backend/spec/models/survey_visit_spec.rb
@@ -3,5 +3,19 @@
 require 'rails_helper'
 
 RSpec.describe SurveyVisit, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'calculating distance_from_home' do
+    let(:home) { create(:home, latitude: '42.3741048', longitude: '-71.126252') }
+
+    it 'performs the calculation before creating the survey visit' do
+      survey_visit = build(:survey_visit, home: home, latitude: '42.3742039', longitude: '-71.1248546')
+      survey_visit.save!
+      survey_visit.distance_from_home = 0.07165586397914082
+    end
+
+    it 'skips calculation if latitude and longitude are blank' do
+      survey_visit = build(:survey_visit, home: home, latitude: nil, longitude: nil)
+      survey_visit.save!
+      survey_visit.distance_from_home = nil
+    end
+  end
 end

--- a/backend/spec/requests/admin/exports_spec.rb
+++ b/backend/spec/requests/admin/exports_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe '/admin/exports', type: :request do
         expected_body = 'Survey Visit ID,Home ID,Successful Export,Public Survey,Assignment ID,' \
         'Assignment Surveyor IDs,Assignment Surveyor Names,Street Number,Street Name,' \
         'Unit Number,City,State,ZIP Code,Home Latitude,Home Longitude,Survey Visit Latitude,' \
-        "Survey Visit Longitude,Survey Visit Time,Surveyor ID,Surveyor Name,Language Code\n"
+        'Survey Visit Longitude,Survey Visit Time,Survey Visit Distance From Home (miles),Surveyor ID,' \
+        "Surveyor Name,Language Code\n"
 
         expect(response.body).to eq(expected_body)
       end


### PR DESCRIPTION
Figured I'd take a crack at this [issue](https://github.com/codeforboston/urban-league-heat-pump-accelerator/issues/653) since I think Joe is no longer working on this [PR](https://github.com/codeforboston/urban-league-heat-pump-accelerator/pull/678)

The PR:
* adds the geocoder gem
* adds new field `survey_distance_to_home` to `survey_visits`
* adds a `before_create` hook to `survey_visit` to calculate the distance between survey visit and home
* adds the field to the CSV export