### PR TITLE
682 assignment table perf fix

### DIFF
--- a/frontend/front/src/pages/Admin/assignment/AssignTable.js
+++ b/frontend/front/src/pages/Admin/assignment/AssignTable.js
@@ -29,10 +29,6 @@ const AssignTable = () => {
   const apiRef = useGridApiRef();
 
   const [selectedSurveyor, setSelectedSurveyor] = useState("");
-  const [paginationModel, setPaginationModel] = useState({
-    page: 0,
-    pageSize: 25,
-  });
 
   // Event handlers
   const handleChange = (event) => {
@@ -44,6 +40,7 @@ const AssignTable = () => {
     data: assignmentsData,
     error: isAssignmentsError,
     isLoading: isAssignmentsDataLoading,
+    isFetching: isAssignmentsDataFetching,
   } = useGetAssignmentsQuery();
 
   const {
@@ -79,10 +76,12 @@ const AssignTable = () => {
       isAddAssignmentLoading ||
       isRemoveAssignmentLoading ||
       isAssignmentsDataLoading ||
+      isAssignmentsDataFetching ||
       isSurveyorsDataLoading,
     [
       isAddAssignmentLoading,
       isAssignmentsDataLoading,
+      isAssignmentsDataFetching,
       isRemoveAssignmentLoading,
       isSurveyorsDataLoading,
     ]
@@ -287,8 +286,9 @@ const AssignTable = () => {
           disableSelectionOnClick
           autoHeight
           checkboxSelection
-          paginationModel={paginationModel}
-          onPaginationModelChange={setPaginationModel}
+          initialState={{
+            pagination: { paginationModel: { page: 0, pageSize: 25 } },
+          }}
           pageSizeOptions={[25, 50, 100]}
         />
       </Box>

--- a/frontend/front/src/pages/Admin/assignment/AssignTable.js
+++ b/frontend/front/src/pages/Admin/assignment/AssignTable.js
@@ -1,5 +1,6 @@
-import { Box, Button, Chip, MenuItem, Stack } from "@mui/material";
-import React, { useMemo, useState } from "react";
+import { useMemo } from "react";
+import { Box, Button, Chip, Stack } from "@mui/material";
+import { DataGrid, useGridApiRef } from "@mui/x-data-grid";
 import {
   useAddAssignmentsToSurveyorMutation,
   useGetAssignmentsQuery,
@@ -10,14 +11,10 @@ import {
   useGoToBreadcrumb,
   useInitBreadcrumbs,
 } from "../../../hooks/breadcrumbHooks";
-
-import FormControl from "@mui/material/FormControl";
-import InputLabel from "@mui/material/InputLabel";
-import Select from "@mui/material/Select";
-import { DataGrid, useGridApiRef } from "@mui/x-data-grid";
+import { ADMIN_ASSIGNMENT, withAdminPrefix } from "../../../routing/routes";
 import CustomSnackbar from "../../../components/CustomSnackbar";
 import Loader from "../../../components/Loader";
-import { ADMIN_ASSIGNMENT, withAdminPrefix } from "../../../routing/routes";
+import SurveyorSelector from "./SurveyorSelect";
 
 const AssignTable = () => {
   const goToBreadcrumb = useGoToBreadcrumb();
@@ -27,13 +24,6 @@ const AssignTable = () => {
   );
 
   const apiRef = useGridApiRef();
-
-  const [selectedSurveyor, setSelectedSurveyor] = useState("");
-
-  // Event handlers
-  const handleChange = (event) => {
-    setSelectedSurveyor(event.target.value);
-  };
 
   // GET hooks
   const {
@@ -87,59 +77,12 @@ const AssignTable = () => {
     ]
   );
 
-  const handleAddSurveyor = async () => {
-    if (!selectedSurveyor) {
-      return;
-    }
-    const selectedAssignments = apiRef.current.getSelectedRows();
-    const assignmentIds = [];
-    selectedAssignments.forEach((assignment) => {
-      const surveyorAssigned = assignment.surveyorData.some(
-        (surveyor) => surveyor.id === selectedSurveyor
-      );
-      // Only adding surveyors to assignments that don't include surveyor
-      if (!surveyorAssigned) {
-        assignmentIds.push(assignment.id);
-      }
-    });
-
-    if (assignmentIds.length > 0) {
-      await addAssignmentsToSurveyor({
-        surveyorId: selectedSurveyor,
-        assignmentIds,
-      }).unwrap();
-    }
-  };
-
-  const handleRemoveSurveyor = async () => {
-    if (!selectedSurveyor) {
-      return;
-    }
-    const selectedAssignments = apiRef.current.getSelectedRows();
-    const assignmentIds = [];
-    selectedAssignments.forEach((assignment) => {
-      const surveyorAssigned = assignment.surveyorData.some(
-        (surveyor) => surveyor.id === selectedSurveyor
-      );
-
-      if (surveyorAssigned) {
-        assignmentIds.push(assignment.id);
-      }
-    });
-
-    if (assignmentIds.length > 0) {
-      await removeAssignmentsFromSurveyor({
-        surveyorId: selectedSurveyor,
-        assignmentIds,
-      });
-    }
-  };
-
   const handleUserLink = (user) => goToBreadcrumb("user", user);
 
   const handleAssignmentLink = (assignment) => {
     goToBreadcrumb("assignment", assignment);
   };
+
   // DataGrid columns
   const columns = [
     {
@@ -238,43 +181,13 @@ const AssignTable = () => {
         <CustomSnackbar message="Error removing assignment" severity="error" />
       )}
 
-      <Stack
-        direction={["column", null, null, "row"]}
-        spacing={1}
-        py={3}
-        gap={1}
-      >
-        <Box sx={{ minWidth: 200 }}>
-          <FormControl fullWidth>
-            <InputLabel id="demo-simple-select-label">Surveyor</InputLabel>
-            <Select
-              labelId="demo-simple-select-label"
-              id="demo-simple-select"
-              value={selectedSurveyor}
-              label="Surveyor"
-              onChange={handleChange}
-            >
-              {(surveyorsData || []).map((surveyor) => (
-                <MenuItem key={surveyor.id} value={surveyor.id}>
-                  {`${surveyor.firstname} ${surveyor.lastname}`}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </Box>
-        <Stack direction="row" gap={1}>
-          <Button size="large" variant="outlined" onClick={handleAddSurveyor}>
-            Add
-          </Button>
-          <Button
-            size="large"
-            variant="outlined"
-            onClick={handleRemoveSurveyor}
-          >
-            Remove
-          </Button>
-        </Stack>
-      </Stack>
+      <SurveyorSelector
+        surveyorsData={surveyorsData}
+        apiRef={apiRef}
+        addAssignmentsToSurveyor={addAssignmentsToSurveyor}
+        removeAssignmentsFromSurveyor={removeAssignmentsFromSurveyor}
+      />
+
       <Box sx={{ height: "100%", width: "100%" }}>
         <DataGrid
           apiRef={apiRef}

--- a/frontend/front/src/pages/Admin/assignment/SurveyorSelect.js
+++ b/frontend/front/src/pages/Admin/assignment/SurveyorSelect.js
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+} from "@mui/material";
+
+const SurveyorSelect = ({
+  surveyorsData,
+  apiRef,
+  addAssignmentsToSurveyor,
+  removeAssignmentsFromSurveyor,
+}) => {
+  const [selectedSurveyor, setSelectedSurveyor] = useState("");
+
+  const handleChange = (event) => {
+    setSelectedSurveyor(event.target.value);
+  };
+
+  const handleAddSurveyor = async () => {
+    if (!selectedSurveyor) {
+      return;
+    }
+    const selectedAssignments = apiRef.current.getSelectedRows();
+    const assignmentIds = [];
+    selectedAssignments.forEach((assignment) => {
+      const surveyorAssigned = assignment.surveyorData.some(
+        (surveyor) => surveyor.id === selectedSurveyor
+      );
+      // Only adding surveyors to assignments that don't include surveyor
+      if (!surveyorAssigned) {
+        assignmentIds.push(assignment.id);
+      }
+    });
+
+    if (assignmentIds.length > 0) {
+      await addAssignmentsToSurveyor({
+        surveyorId: selectedSurveyor,
+        assignmentIds,
+      }).unwrap();
+    }
+  };
+
+  const handleRemoveSurveyor = async () => {
+    if (!selectedSurveyor) {
+      return;
+    }
+    const selectedAssignments = apiRef.current.getSelectedRows();
+    const assignmentIds = [];
+    selectedAssignments.forEach((assignment) => {
+      const surveyorAssigned = assignment.surveyorData.some(
+        (surveyor) => surveyor.id === selectedSurveyor
+      );
+      // Only removing surveyors from assignments that include surveyor
+      if (surveyorAssigned) {
+        assignmentIds.push(assignment.id);
+      }
+    });
+
+    if (assignmentIds.length > 0) {
+      await removeAssignmentsFromSurveyor({
+        surveyorId: selectedSurveyor,
+        assignmentIds,
+      });
+    }
+  };
+
+  return (
+    <Stack direction={["column", null, null, "row"]} spacing={1} py={3} gap={1}>
+      <Box sx={{ minWidth: 200 }}>
+        <FormControl fullWidth>
+          <InputLabel id="surveyor-select-label">Surveyor</InputLabel>
+          <Select
+            labelId="surveyor-select-label"
+            id="surveyor-select"
+            value={selectedSurveyor}
+            label="Surveyor"
+            onChange={handleChange}
+          >
+            {(surveyorsData || []).map((surveyor) => (
+              <MenuItem key={surveyor.id} value={surveyor.id}>
+                {`${surveyor.firstname} ${surveyor.lastname}`}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+      <Stack direction="row" gap={1}>
+        <Button size="large" variant="outlined" onClick={handleAddSurveyor}>
+          Add
+        </Button>
+        <Button size="large" variant="outlined" onClick={handleRemoveSurveyor}>
+          Remove
+        </Button>
+      </Stack>
+    </Stack>
+  );
+};
+
+export default SurveyorSelect;


### PR DESCRIPTION
- Added client-side pagination to reduce the initial number rows 
- Removed React state and use the DataGrid's [GridApi](https://v6.mui.com/x/api/data-grid/grid-api/). This seemed to speed up row selection.
- Add an isFetching flag to show loading spinner when making assignment updates/removals.
- Modify the add/remove handlers so that surveyors already assigned are not added again, and only those assigned to the selected assignments can be removed.
- Move `SurveyorSelect.js` into it's own file, now we are preventing `AssignTable.js` to be re-rendered on every surveyor change.