### PR TITLE
Add 'Surveyor not able to get to the door' option to Q1

### DIFF
--- a/backend/lib/seeds/survey_questions/en_offline.csv
+++ b/backend/lib/seeds/survey_questions/en_offline.csv
@@ -1,5 +1,5 @@
 display_order,text,response_type,response_options
-1,"Are you the homeowner?",0,"Yes (proceed to next question)/No ->  “Can we leave this info with you, for the homeowner?”/No one answered the door/Door answered, survey declined"
+1,"Are you the homeowner?",0,"Yes (proceed to next question)/No ->  "Can we leave this info with you, for the homeowner?"/No one answered the door/Door answered, survey declined/Surveyor not able to get to the door"
 2,"If you could save money on your utility bills with a state-discounted or free heating & cooling system upgrade, would you like to learn more?",0,"Yes/No"
 3,"If “No” then can you share why you are not interested in moving forward?",1,""
 4,"Have you heard of “heat pumps” for home heating and cooling?",0,"Yes/No"


### PR DESCRIPTION
Updates the in-person survey question "Are you the homeowner?" to include a new response option: "Surveyor not able to get to the door"

Fixes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)