### PR TITLE
Record public survey lang pref for new relic

### DIFF
--- a/frontend/front/src/features/newrelic/LanguageLogger.js
+++ b/frontend/front/src/features/newrelic/LanguageLogger.js
@@ -1,9 +1,10 @@
 import { useEffect } from "react";
 import { logLanguagePref } from ".";
+import i18next from "i18next";
 
 export const LanguageLogger = () => {
   useEffect(() => {
-    const currentLang = localStorage.getItem("langPref");
+    const currentLang = i18next.language;
     logLanguagePref(currentLang, "initial_load");
   }, []);
 

--- a/frontend/front/src/features/newrelic/index.js
+++ b/frontend/front/src/features/newrelic/index.js
@@ -35,14 +35,14 @@ if (isNewRelicEnabled()) {
   newrelic = new BrowserAgent(options);
 }
 
-export const logSurveyPageVisit = () => {
+export const logSurveyPageVisit = (language) => {
   if (!newrelic) return;
-  newrelic.addPageAction("surveyPageVisit");
+  newrelic.addPageAction("surveyPageVisit", { language });
 };
 
-export const logSurveySubmission = () => {
+export const logSurveySubmission = (language) => {
   if (!newrelic) return;
-  newrelic.addPageAction("surveySubmission");
+  newrelic.addPageAction("surveySubmission", { language });
 };
 
 export const logLanguagePref = (language, source) => {

--- a/frontend/front/src/pages/Public/Pages/SurveyPage.js
+++ b/frontend/front/src/pages/Public/Pages/SurveyPage.js
@@ -1,6 +1,7 @@
 import { Alert, Box, Container, Snackbar, Stack } from "@mui/material";
 import React, { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import i18next from "i18next";
 
 import {
   useCreateHomeMutation,
@@ -76,7 +77,7 @@ export const SurveyPage = () => {
   );
 
   useEffect(() => {
-    logSurveyPageVisit();
+    logSurveyPageVisit(i18next.language);
   }, []);
 
   useEffect(() => {
@@ -85,13 +86,13 @@ export const SurveyPage = () => {
     }
     if (isSurveyVisitSucess) {
       setStep(STEP_THANKS);
-      logSurveySubmission();
+      logSurveySubmission(i18next.language);
     }
   }, [isCreateHomeSucccess, isSurveyVisitSucess]);
 
   useEffect(() => {
     if (isCreateHomeSucccess) {
-      const language = localStorage.getItem("langPref");
+      const language = i18next.language;
       logSurveyPageVisit(language);
     }
   }, [isCreateHomeSucccess]);


### PR DESCRIPTION
- Recording user's lang pref when they visit and complete the public survey in new relic
- Remove local storage as the source of lang pref as first time visitors will not have a lang pref set